### PR TITLE
chore: use eslint directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint \"**/*.{ts,tsx}\"",
     "format": "prettier \"**/*.{ts,tsx,js,css,json,yml,md}\" --write",
     "format:check": "prettier \"**/*.{ts,tsx,js,css,json,yml,md}\" --check",
     "type:check": "tsc"


### PR DESCRIPTION
## Summary
`next lint`를 사용하지 않고 ESLint를 직접적으로 사용해서 다음과 같이 GitHub 코드에서 오류가 뜨는 라인을 볼 수 있게 합니다.
![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/504016ba-e976-4541-99f2-f73ab292bc6a)
