### PR TITLE
refactor: rename `<Tier />` to `<TierImage />`

### DIFF
--- a/src/components/common/TierImage.tsx
+++ b/src/components/common/TierImage.tsx
@@ -19,11 +19,11 @@ const alts: Record<Tier, string> = {
   challenger: '챌린저',
 };
 
-interface TierProps extends Omit<ImageProps, 'src' | 'alt'> {
+interface TierImageProps extends Omit<ImageProps, 'src' | 'alt'> {
   tier: Tier;
 }
 
-export default function Tier(props: TierProps) {
+export default function TierImage(props: TierImageProps) {
   const { tier, ...restProps } = props;
 
   return <Image src={tiers[tier]} alt={alts[tier]} {...restProps} />;


### PR DESCRIPTION
## Summary
`Tier` 타입과 이름 충돌 방지를 위해 `<TierImage />`로 컴포넌트 이름을 변견했습니다.
