### PR TITLE
chore: ignore some checks on build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,12 @@ const nextConfig = {
   compiler: {
     emotion: true,
   },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
   webpack: (config) => {
     config.module.rules.push({
       test: /\.svg$/,


### PR DESCRIPTION
## Summary
CI 상에서 린팅과 타입 체킹을 하기 때문에 `next build`에서 동일한 역할을 하는 기능을 껐습니다.
