### PR TITLE
feat: turn off default emotion prefixer plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend-gnimty",
       "version": "0.1.0",
       "dependencies": {
+        "@emotion/cache": "^11.11.0",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@tanstack/react-query": "^4.35.7",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "type:check": "tsc"
   },
   "dependencies": {
+    "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@tanstack/react-query": "^4.35.7",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,17 +1,25 @@
 import '@/styles/globals.css';
-import { ThemeProvider } from '@emotion/react';
+import createCache from '@emotion/cache';
+import { CacheProvider, ThemeProvider } from '@emotion/react';
 
 import MainLayout from '@/components/layout/MainLayout';
 import theme from '@/styles/theme';
 
 import type { AppProps } from 'next/app';
 
+const emotionCache = createCache({
+  key: 'css',
+  stylisPlugins: [],
+});
+
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <ThemeProvider theme={theme}>
-      <MainLayout>
-        <Component {...pageProps} />
-      </MainLayout>
-    </ThemeProvider>
+    <CacheProvider value={emotionCache}>
+      <ThemeProvider theme={theme}>
+        <MainLayout>
+          <Component {...pageProps} />
+        </MainLayout>
+      </ThemeProvider>
+    </CacheProvider>
   );
 }


### PR DESCRIPTION
## Summary
Emotion에서 기본적으로 제공하는 prefixer 플러그인을 제거하여 vendor prefix가 추가되지 않게 했습니다.
