### PR TITLE
chore: add image remote pattern for lol cdn

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,16 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  images: {
+    remotePatterns: [
+      // TODO: 챔피언 이미지 등의 리소스들을 어떻게 처리할지 결정나면 변경 혹은 삭제
+      {
+        protocol: 'https',
+        hostname: 'ddragon.leagueoflegends.com',
+        pathname: '/cdn/**',
+      },
+    ],
+  },
   webpack: (config) => {
     const fileLoaderRule = config.module.rules.find((rule) => rule.test?.test?.('.svg'));
     config.module.rules.push({


### PR DESCRIPTION
## Summary
`https://ddragon.leagueoflegends.com/cdn/**` 에 대한 이미지 소스를 허용하는 설정을 추가했습니다.
