### PR TITLE
fix: image remotePattern 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'ddragon.leagueoflegends.com',
+        pathname: '**/*.png',
+      },
+    ],
+  },
   compiler: {
     emotion: true,
   },
@@ -9,16 +18,6 @@ const nextConfig = {
   },
   typescript: {
     ignoreBuildErrors: true,
-  },
-  images: {
-    remotePatterns: [
-      // TODO: 챔피언 이미지 등의 리소스들을 어떻게 처리할지 결정나면 변경 혹은 삭제
-      {
-        protocol: 'https',
-        hostname: 'ddragon.leagueoflegends.com',
-        pathname: '/cdn/**',
-      },
-    ],
   },
   webpack: (config) => {
     const fileLoaderRule = config.module.rules.find((rule) => rule.test?.test?.('.svg'));


### PR DESCRIPTION
## Summary

- next.config.js의 image remotePattern 수정

## Describe your changes

- remotePattern에 riot static api의 모든 png를 받아올 수 있게 작성하였습니다.

## Issue ID and link

- [38](https://www.notion.so/next-config-1061deae1b334605b9cc268e9b88095e)
