### PR TITLE
refactor: import type `Theme` from `@emotion/react`

### DIFF
--- a/src/components/common/ChampionTierBadge.style.tsx
+++ b/src/components/common/ChampionTierBadge.style.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
 
 import type { ChampionTier } from '@/api/types';
-import type { Theme } from '@/styles/theme/emotionTheme';
+
+import type { Theme } from '@emotion/react';
 
 const tierBackground = (theme: Theme): Record<ChampionTier, string> => ({
   '1': theme.colors.red800,

--- a/src/components/common/select/Select.style.tsx
+++ b/src/components/common/select/Select.style.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import type { Theme } from '@/styles/theme/emotionTheme';
+import type { Theme } from '@emotion/react';
 
 export const selectWrapper = css({
   position: 'relative',

--- a/src/components/pages/main/RecentMatches.style.tsx
+++ b/src/components/pages/main/RecentMatches.style.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import type { Theme } from '@/styles/theme';
+import type { Theme } from '@emotion/react';
 
 export const recentMatchesRoot = (theme: Theme) =>
   css({

--- a/src/components/pages/main/UserCardLandscape.style.tsx
+++ b/src/components/pages/main/UserCardLandscape.style.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import type { Theme } from '@/styles/theme/emotionTheme';
+import type { Theme } from '@emotion/react';
 
 export const userCardLandscape = (theme: Theme) =>
   css({


### PR DESCRIPTION
## Summary
`dev` 브랜치에서 실패한 타입체킹을 고치는김에  `import type { Theme } from '@/styles/theme/emotionTheme';`을 전부 `import type { Theme } from '@emotion/react';` 로 바꿨습니다.

