### PR TITLE
fix: use number unit for `fontWeight`

### DIFF
--- a/src/styles/theme/constants/fonts.ts
+++ b/src/styles/theme/constants/fonts.ts
@@ -2,36 +2,36 @@ export const fonts = {
   h1: {
     fontSize: '40px',
     lineHeight: '52px',
-    fontWeight: 'bold',
+    fontWeight: 700,
   },
   h2: {
     fontSize: '28px',
     lineHeight: '36px',
-    fontWeight: 'bold',
+    fontWeight: 700,
   },
   h3: {
     fontSize: '20px',
     lineHeight: '28px',
-    fontWeight: 'bold',
+    fontWeight: 700,
   },
   t1: {
     fontSize: '16px',
     lineHeight: '22px',
-    fontWeight: 'bold',
+    fontWeight: 700,
   },
   t2: {
     fontSize: '14px',
     lineHeight: '20px',
-    fontWeight: 'bold',
+    fontWeight: 700,
   },
   body: {
     fontSize: '12px',
     lineHeight: '16px',
-    fontWeight: 'regular',
+    fontWeight: 400,
   },
   caption: {
     fontSize: '10px',
     lineHeight: '14px',
-    fontWeight: 'regular',
+    fontWeight: 400,
   },
 };


### PR DESCRIPTION
## Summary
`fontWeight`의 단위에 숫자를 사용합니다.

## Describe your changes
- 이전의 `regular` 값은 기본 CSS에서는 올바르지 않은 값이어서 Emotion에서 유효하지 않은 값으로 받아 들입니다.
- 좀 더 명확하게 글꼴의 굵기를 알 수 있습니다.

