### PR TITLE
feat: `<PatchNoteBanner />`

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,11 @@ const nextConfig = {
   },
   images: {
     remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.contentstack.io',
+        pathname: '/v3/assets/**',
+      },
       // TODO: 챔피언 이미지 등의 리소스들을 어떻게 처리할지 결정나면 변경 혹은 삭제
       {
         protocol: 'https',

--- a/src/api/mocks/patchVersion.ts
+++ b/src/api/mocks/patchVersion.ts
@@ -1,0 +1,10 @@
+import type { PatchVersion } from '../types';
+
+const patchVersion: PatchVersion = {
+  version: '13.19.1',
+  releaseNoteUrl: 'https://www.leagueoflegends.com/ko-kr/news/game-updates/patch-13-19-notes/',
+  releaseNoteImgUrl:
+    'https://images.contentstack.io/v3/assets/blt731acb42bb3d1659/blt0cfea10deca29f0e/64e7e07cf1ac3dc86df8ff19/2023-Key-Art.jpg',
+};
+
+export default patchVersion;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -42,3 +42,9 @@ export interface SkinSaleRes {
   skinImgUrl: string;
   discountedRate: number;
 }
+
+export interface PatchVersion {
+  version: string;
+  releaseNoteUrl: string;
+  releaseNoteImgUrl: string;
+}

--- a/src/components/pages/information/PatchNoteBanner.tsx
+++ b/src/components/pages/information/PatchNoteBanner.tsx
@@ -1,12 +1,9 @@
 import { Box, Heading, Link, VStack } from '@chakra-ui/react';
 
+import patchVersion from '@/api/mocks/patchVersion';
+
 export default function PatchNoteBanner() {
-  const data = {
-    version: '13.19.1',
-    releaseNoteUrl: 'https://www.leagueoflegends.com/ko-kr/news/game-updates/patch-13-19-notes/',
-    releaseNoteImgUrl:
-      'https://images.contentstack.io/v3/assets/blt731acb42bb3d1659/blt0cfea10deca29f0e/64e7e07cf1ac3dc86df8ff19/2023-Key-Art.jpg',
-  };
+  const data = patchVersion;
 
   const majorMinorVersion = data.version.split('.').slice(0, 2).join('.');
 

--- a/src/components/pages/information/PatchNoteBanner.tsx
+++ b/src/components/pages/information/PatchNoteBanner.tsx
@@ -5,7 +5,7 @@ import patchVersion from '@/api/mocks/patchVersion';
 export default function PatchNoteBanner() {
   const data = patchVersion;
 
-  const majorMinorVersion = data.version.split('.', 2).join('.');
+  const majorMinorVersion = data.version.replace(/\.\d+$/, '');
 
   return (
     <Link

--- a/src/components/pages/information/PatchNoteBanner.tsx
+++ b/src/components/pages/information/PatchNoteBanner.tsx
@@ -1,0 +1,42 @@
+import { Box, Heading, Link, VStack } from '@chakra-ui/react';
+
+export default function PatchNoteBanner() {
+  const data = {
+    version: '13.19.1',
+    releaseNoteUrl: 'https://www.leagueoflegends.com/ko-kr/news/game-updates/patch-13-19-notes/',
+    releaseNoteImgUrl:
+      'https://images.contentstack.io/v3/assets/blt731acb42bb3d1659/blt0cfea10deca29f0e/64e7e07cf1ac3dc86df8ff19/2023-Key-Art.jpg',
+  };
+
+  const majorMinorVersion = data.version.split('.').slice(0, 2).join('.');
+
+  return (
+    <Link
+      href={data.releaseNoteUrl}
+      display="block"
+      w="1080px"
+      h="320px"
+      pos="relative"
+      borderRadius="8px"
+      background={`linear-gradient(0deg, rgb(0 0 0 / .4) 0%, rgb(0 0 0 / .4) 100%), url('${data.releaseNoteImgUrl}') no-repeat center/cover, lightgray`}
+      textDecor="none"
+    >
+      <VStack w="full" h="full" gap="12px" justifyContent="center">
+        <Heading as="h2" color="white" textStyle="h2" fontWeight="bold">
+          {majorMinorVersion} 패치노트
+        </Heading>
+        <Box
+          textStyle="t2"
+          fontWeight="bold"
+          color="white"
+          p="10px 12px"
+          border="1px solid"
+          borderColor="gray200"
+          borderRadius="4px"
+        >
+          패치노트 보러가기
+        </Box>
+      </VStack>
+    </Link>
+  );
+}

--- a/src/components/pages/information/PatchNoteBanner.tsx
+++ b/src/components/pages/information/PatchNoteBanner.tsx
@@ -5,7 +5,7 @@ import patchVersion from '@/api/mocks/patchVersion';
 export default function PatchNoteBanner() {
   const data = patchVersion;
 
-  const majorMinorVersion = data.version.split('.').slice(0, 2).join('.');
+  const majorMinorVersion = data.version.split('.', 2).join('.');
 
   return (
     <Link


### PR DESCRIPTION
## Summary
할인/패치노트 페이지에 사용할 컴포넌트를 추가했습니다.

## Describe your changes
- 렌더링 된 모습:
  ![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/c08207c8-68ee-45c1-9b91-5e1721f97f99)
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=1604-27849&mode=dev)
