### PR TITLE
feat: `<OnSaleChampions />`

### DIFF
--- a/src/api/mocks/championSales.ts
+++ b/src/api/mocks/championSales.ts
@@ -1,0 +1,60 @@
+import type { ChampionSaleRes } from '../types';
+
+const championSales: ChampionSaleRes[] = [
+  {
+    championId: 68,
+    krName: '럼블',
+    enName: 'Rumble',
+    originRp: 880,
+    discountedRp: 440,
+    discountedRate: 50,
+    originIp: 4800,
+  },
+  {
+    championId: 4,
+    krName: '트위스티드 페이트',
+    enName: 'TwistedFate',
+    originRp: 260,
+    discountedRp: 130,
+    discountedRate: 50,
+    originIp: 4800,
+  },
+  {
+    championId: 221,
+    krName: '제리',
+    enName: 'Zeri',
+    originRp: 975,
+    discountedRp: 633,
+    discountedRate: 35,
+    originIp: 6300,
+  },
+  {
+    championId: 112,
+    krName: '빅토르',
+    enName: 'Viktor',
+    originRp: 880,
+    discountedRp: 395,
+    discountedRate: 55,
+    originIp: 4800,
+  },
+  {
+    championId: 53,
+    krName: '블리츠크랭크',
+    enName: 'Blitzcrank',
+    originRp: 585,
+    discountedRp: 263,
+    discountedRate: 55,
+    originIp: 1350,
+  },
+  {
+    championId: 84,
+    krName: '아칼리',
+    enName: 'Akali',
+    originRp: 790,
+    discountedRp: 316,
+    discountedRate: 60,
+    originIp: 3150,
+  },
+];
+
+export default championSales;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -48,3 +48,13 @@ export interface PatchVersion {
   releaseNoteUrl: string;
   releaseNoteImgUrl: string;
 }
+
+export interface ChampionSaleRes {
+  championId: number;
+  enName: string;
+  krName: string;
+  originRp: number;
+  discountedRp: number;
+  discountedRate: number;
+  originIp: number;
+}

--- a/src/assets/images/ip.svg
+++ b/src/assets/images/ip.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" fill-rule="evenodd"
+    d="m14.792 5.064-3.843-3.956-6.722 7.914 5.763 1.98 4.802-5.938Zm.961 2.97-3.842 3.956 3.842 1.979L18.634 11l-2.88-2.968Zm-4.804 12.86 3.843-4.946L3.267 11l7.682 9.894Z"
+    clip-rule="evenodd" />
+</svg>

--- a/src/components/pages/information/OnSaleCard.tsx
+++ b/src/components/pages/information/OnSaleCard.tsx
@@ -1,6 +1,7 @@
 import { Box, Center, Flex, HStack, VStack } from '@chakra-ui/react';
 import Image from 'next/image';
 
+import Ip from '@/assets/images/ip.svg';
 import Rp from '@/assets/images/rp.svg';
 
 import type { StackProps } from '@chakra-ui/react';
@@ -11,10 +12,11 @@ interface OnSaleCardProps extends StackProps {
   originRp: number;
   discountedRp: number;
   discountedRate: number;
+  originIp?: number;
 }
 
 export default function OnSaleCard(props: OnSaleCardProps) {
-  const { name, imgUrl, originRp, discountedRp, discountedRate, ...restProps } = props;
+  const { name, imgUrl, originRp, discountedRp, discountedRate, originIp, ...restProps } = props;
 
   return (
     <VStack gap="12px" {...restProps}>
@@ -53,6 +55,16 @@ export default function OnSaleCard(props: OnSaleCardProps) {
               {discountedRp}
             </Box>
           </HStack>
+          {originIp !== undefined ? (
+            <HStack gap="4px">
+              <Flex color="ip">
+                <Ip width={22} height={22} />
+              </Flex>
+              <Box textStyle="t1" fontWeight="bold" color="gray800">
+                {originIp}
+              </Box>
+            </HStack>
+          ) : null}
         </HStack>
       </HStack>
     </VStack>

--- a/src/components/pages/information/OnSaleCard.tsx
+++ b/src/components/pages/information/OnSaleCard.tsx
@@ -1,0 +1,60 @@
+import { Box, Center, Flex, HStack, VStack } from '@chakra-ui/react';
+import Image from 'next/image';
+
+import Rp from '@/assets/images/rp.svg';
+
+import type { StackProps } from '@chakra-ui/react';
+
+interface OnSaleCardProps extends StackProps {
+  name: string;
+  imgUrl: string;
+  originRp: number;
+  discountedRp: number;
+  discountedRate: number;
+}
+
+export default function OnSaleCard(props: OnSaleCardProps) {
+  const { name, imgUrl, originRp, discountedRp, discountedRate, ...restProps } = props;
+
+  return (
+    <VStack gap="12px" {...restProps}>
+      <Box pos="relative" w="352px" h="200px">
+        <Image src={imgUrl} fill alt="" css={{ borderRadius: '8px' }} />
+        <Center
+          pos="absolute"
+          top="12px"
+          right="12px"
+          w="48px"
+          h="48px"
+          bg="rgb(222 46 57 / .6)"
+          border="1px solid"
+          borderColor="main"
+          borderRadius="9999px"
+          textStyle="t2"
+          fontWeight="bold"
+          color="white"
+        >
+          -{discountedRate}%
+        </Center>
+      </Box>
+      <HStack w="352px" px="12px" justifyContent="space-between" gap="12px">
+        <Box textStyle="t1" fontWeight="bold">
+          {name}
+        </Box>
+        <HStack gap="8px">
+          <Box textStyle="t2" fontWeight="regular" color="gray500" textDecor="line-through">
+            {originRp}
+          </Box>
+          <HStack gap="4px">
+            <Flex color="rp">
+              <Rp width={22} height={22} />
+            </Flex>
+            <Box textStyle="t1" fontWeight="bold" color="gray800">
+              {discountedRp}
+            </Box>
+          </HStack>
+        </HStack>
+      </HStack>
+    </VStack>
+  );
+}

--- a/src/components/pages/information/OnSaleChampions.tsx
+++ b/src/components/pages/information/OnSaleChampions.tsx
@@ -1,0 +1,26 @@
+import { Grid } from '@chakra-ui/react';
+
+import championSales from '@/api/mocks/championSales';
+
+import OnSaleCard from './OnSaleCard';
+
+export default function OnSaleChampions() {
+  const onSaleChampions = championSales;
+
+  return (
+    <Grid as="ul" gap="12px" templateColumns="repeat(3, 352px)">
+      {onSaleChampions.map((champ) => (
+        <OnSaleCard
+          key={champ.championId}
+          as="li"
+          name={champ.krName}
+          imgUrl={`https://cdn-store.leagueoflegends.co.kr/images/v2/champion-splashes/${champ.championId}000.jpg`}
+          originRp={champ.originRp}
+          discountedRp={champ.discountedRp}
+          discountedRate={champ.discountedRate}
+          originIp={champ.originIp}
+        />
+      ))}
+    </Grid>
+  );
+}

--- a/src/components/pages/information/OnSaleSkins.tsx
+++ b/src/components/pages/information/OnSaleSkins.tsx
@@ -1,8 +1,8 @@
-import { Box, Center, Flex, Grid, HStack, VStack } from '@chakra-ui/react';
-import Image from 'next/image';
+import { Grid } from '@chakra-ui/react';
 
 import skinSales from '@/api/mocks/skinSales';
-import Rp from '@/assets/images/rp.svg';
+
+import OnSaleCard from './OnSaleCard';
 
 export default function OnSaleSkins() {
   const onSaleSkins = skinSales;
@@ -10,45 +10,15 @@ export default function OnSaleSkins() {
   return (
     <Grid as="ul" gap="12px" templateColumns="repeat(3, 352px)">
       {onSaleSkins.map((skin) => (
-        <VStack key={skin.skinName} as="li" gap="12px">
-          <Box pos="relative" w="352px" h="200px">
-            <Image src={skin.skinImgUrl} fill alt="" css={{ borderRadius: '8px' }} />
-            <Center
-              pos="absolute"
-              top="12px"
-              right="12px"
-              w="48px"
-              h="48px"
-              bg="rgb(222 46 57 / .6)"
-              border="1px solid"
-              borderColor="main"
-              borderRadius="9999px"
-              textStyle="t2"
-              fontWeight="bold"
-              color="white"
-            >
-              -{skin.discountedRate}%
-            </Center>
-          </Box>
-          <HStack w="352px" px="12px" justifyContent="space-between" gap="12px">
-            <Box textStyle="t1" fontWeight="bold">
-              {skin.skinName}
-            </Box>
-            <HStack gap="8px">
-              <Box textStyle="t2" fontWeight="regular" color="gray500" textDecor="line-through">
-                {skin.originRp}
-              </Box>
-              <HStack gap="4px">
-                <Flex color="rp">
-                  <Rp width={22} height={22} />
-                </Flex>
-                <Box textStyle="t1" fontWeight="bold" color="gray800">
-                  {skin.discountedRp}
-                </Box>
-              </HStack>
-            </HStack>
-          </HStack>
-        </VStack>
+        <OnSaleCard
+          key={skin.skinName}
+          as="li"
+          name={skin.skinName}
+          imgUrl={skin.skinImgUrl}
+          originRp={skin.originRp}
+          discountedRp={skin.discountedRp}
+          discountedRate={skin.discountedRate}
+        />
       ))}
     </Grid>
   );

--- a/src/styles/theme/constants/colors.ts
+++ b/src/styles/theme/constants/colors.ts
@@ -88,6 +88,7 @@ export const colors = {
   magenta700: '#F147B6',
   magenta800: '#EE19A4',
 
+  ip: '#0acbe6',
   rp: '#c79a3b',
 
   kakao: '#FEE500',


### PR DESCRIPTION
## Summary
할인/패치노트 페이지에 사용할 컴포넌트를 추가했습니다.

## Describe your changes
- #67 의 `<OnSaleSkins />`와 공통 로직을 추출한 후 그 컴포넌트를 사용해서 작성했습니다. 
- 렌더링 된 모습:
  ![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/ae390c6a-87f6-449d-8376-283dbdbe681c)
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=1604-31201&mode=dev)
