### PR TITLE
feat: `<Pagination />`

### DIFF
--- a/src/assets/icons/system/back.svg
+++ b/src/assets/icons/system/back.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path stroke="currentColor" stroke-linecap="round" d="m15 6-6 6 6 6" />
+</svg>

--- a/src/assets/icons/system/next.svg
+++ b/src/assets/icons/system/next.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path stroke="currentColor" stroke-linecap="round" d="m9 18 6-6-6-6" />
+</svg>

--- a/src/components/pages/rankings/Pagination.tsx
+++ b/src/components/pages/rankings/Pagination.tsx
@@ -1,0 +1,55 @@
+import { Link } from '@chakra-ui/next-js';
+import { Flex } from '@chakra-ui/react';
+
+import Back from '@/assets/icons/system/back.svg';
+import Next from '@/assets/icons/system/next.svg';
+
+import type { StackProps } from '@chakra-ui/react';
+
+interface PaginationProps extends StackProps {
+  currentPage: number;
+  totalItems: number;
+  maxItemsInPage: number;
+}
+
+export default function Pagination(props: PaginationProps) {
+  const { currentPage, totalItems, maxItemsInPage, ...restProps } = props;
+
+  const totalPages = Math.ceil(totalItems / maxItemsInPage);
+  const currentPagination = Math.ceil(currentPage / 10);
+  const currentPaginationPages = Math.min(totalPages - (currentPagination - 1) * 10, 10);
+  // 첫번째 페이지네이션에서 0으로 계산되는 것을 방지하기 위해 `Math.max()` 사용
+  const prevPaginationPage = Math.max((currentPagination - 1) * 10, 1);
+  const nextPaginationPage = Math.min(currentPagination * 10 + 1, totalPages);
+
+  return (
+    <Flex justifyContent="space-between" alignItems="center" w="1080px" {...restProps}>
+      <Link href={`/rankings?page=${prevPaginationPage}`} aria-label={`${prevPaginationPage}로 이동`} color="gray800">
+        <Back width={24} height={24} aria-hidden css={{ display: 'block' }} />
+      </Link>
+      <Flex gap="12px">
+        {Array.from({ length: currentPaginationPages }).map((_, i) => {
+          const page = (currentPagination - 1) * 10 + i + 1;
+          const isCurrentPage = page === currentPage;
+          return (
+            <Link
+              key={page}
+              href={`/rankings?page=${page}`}
+              minW="24px"
+              textStyle="t2"
+              fontWeight={isCurrentPage ? 'bold' : 'normal'}
+              color={isCurrentPage ? 'gray800' : 'gray500'}
+              textAlign="center"
+              textDecor="none"
+            >
+              {page}
+            </Link>
+          );
+        })}
+      </Flex>
+      <Link href={`/rankings?page=${nextPaginationPage}`} aria-label={`${nextPaginationPage}로 이동`} color="gray800">
+        <Next width={24} height={24} aria-hidden css={{ display: 'block' }} />
+      </Link>
+    </Flex>
+  );
+}


### PR DESCRIPTION
## Summary
랭킹 페이지에서 사용할 `<Pagination />` 컴포넌트를 추가했습니다.

## Describe your changes
- 좀 더 추상화할 부분이 보이지만 현재로서는 페이지네이션이 사용되는 부분이 랭킹 페이지밖에 없고 피그마에서 컴포넌트화 되어 있지 않기 때문에 다른 부분에서 사용될 때 어떻게 사용될지 짐작이 안가서 일부러 추상화를 시키지 않았습니다.
- 사용법은 다음과 같습니다.
  ```tsx
  <Pagination currentPage={288} totalItems={28723} maxItemsInPage={100} />
  ```
- 렌더링 된 모습:
  ![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/9b28c2b5-3e55-4f60-9d0c-7a886d0872db)
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=1185-22313&mode=dev)
