### PR TITLE
feat: add `/rankings` page

### DIFF
--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -13,7 +13,7 @@ const links = [
   { name: '홈', link: '/' },
   { name: '듀오 찾기', link: '' },
   { name: '챔피언 분석', link: '' },
-  { name: '랭킹', link: '' },
+  { name: '랭킹', link: '/rankings?page=1' },
   { name: '할인/패치노트', link: '/information' },
 ];
 

--- a/src/components/pages/rankings/Rankings.tsx
+++ b/src/components/pages/rankings/Rankings.tsx
@@ -1,0 +1,63 @@
+import { Flex, Heading } from '@chakra-ui/react';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import rankTiersQuery from '@/apis/queries/rankTiersQuery';
+import type { GameMode } from '@/apis/types';
+import Select from '@/components/common/select/Select';
+import type { SelectOption } from '@/components/common/select/useSelect';
+import usePagination from '@/hooks/usePagination';
+
+import Pagination from './Pagination';
+import RankingsTable from './RankingsTable';
+import TopThreeSection from './TopThreeSection';
+
+const queueSelectOptions: SelectOption<GameMode>[] = [
+  {
+    text: '솔로 랭크',
+    value: 'RANK_SOLO',
+  },
+  {
+    text: '자유 랭크',
+    value: 'RANK_FLEX',
+  },
+];
+
+interface RankingsInnerProps {
+  page: number;
+}
+
+/**
+ * `useSuspenseQuery()`는 `enabled` 옵션이 지원되지 않는 문제 때문에
+ * 컴포넌트를 나눴습니다.
+ * 참고: {@link https://github.com/TanStack/query/discussions/6206}
+ */
+function RankingsInner(props: RankingsInnerProps) {
+  const { page } = props;
+  const { data } = useSuspenseQuery(rankTiersQuery({ page }));
+
+  return (
+    <Flex flexDir="column" w="1080px" m="40px auto 60px">
+      <Heading as="h1" textStyle="h2" fontWeight="bold" color="gray800">
+        소환사 랭킹
+      </Heading>
+      <Flex mt="24px" justifyContent="space-between">
+        <Flex>
+          <Select options={queueSelectOptions} css={{ width: '140px' }} />
+        </Flex>
+      </Flex>
+      <TopThreeSection mt="24px" />
+      <RankingsTable ranks={data.data.ranks} mt="24px" />
+      <Pagination currentPage={page} totalItems={data.data.totalSummoners} maxItemsInPage={100} mt="40px" />
+    </Flex>
+  );
+}
+
+export default function Rankings() {
+  const page = usePagination();
+
+  if (page === undefined) {
+    return;
+  }
+
+  return <RankingsInner page={page} />;
+}

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,28 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+function isPositive(str: string): boolean {
+  return /^[1-9]\d*$/.test(str);
+}
+
+export default function usePagination() {
+  const [page, setPage] = useState<number | undefined>(undefined);
+
+  const router = useRouter();
+  const { page: pageStr } = router.query;
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+    if (pageStr === undefined) {
+      setPage(1);
+    } else if (typeof pageStr === 'string' && isPositive(pageStr)) {
+      setPage(parseInt(pageStr, 10));
+    } else {
+      router.replace('/404');
+    }
+  }, [pageStr, router]);
+
+  return page;
+}

--- a/src/pages/rankings.tsx
+++ b/src/pages/rankings.tsx
@@ -1,0 +1,14 @@
+import Head from 'next/head';
+
+import Rankings from '@/components/pages/rankings/Rankings';
+
+export default function RankingsRoute() {
+  return (
+    <>
+      <Head>
+        <title>소환사 랭킹</title>
+      </Head>
+      <Rankings />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
`/rankings` 페이지를 추가했습니다.

## Describe your changes
- 렌더링 된 모습:
  ![localhost_3000_rankings_page=1](https://github.com/gnimty/frontend-gnimty/assets/72999818/f1d55657-eeeb-4d4e-a466-7c2c0f6131e4)

- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=1130-20421&mode=dev)