### PR TITLE
feat: add OP badge

### DIFF
--- a/src/components/common/ChampionTierBadge.style.tsx
+++ b/src/components/common/ChampionTierBadge.style.tsx
@@ -10,7 +10,7 @@ const tierBackground = (theme: Theme): Record<ChampionTier, string> => ({
   '3': theme.colors.yellow800,
   '4': theme.colors.green800,
   '5': theme.colors.blue800,
-  OP: '',
+  OP: theme.colors.purple800,
   RIP: '',
 });
 


### PR DESCRIPTION
## Summary
새로 추가된 챔피언 OP 티어 뱃지를 추가했습니다.

## Describe your changes
- 렌더링 된 모습:
  ![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/e8dd5e9d-a439-4844-b210-61907d8ddd7a)
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=2912-345&mode=dev)
