### PR TITLE
fix: wrap in many rotation champions

### DIFF
--- a/src/components/pages/information/RotationChampions.tsx
+++ b/src/components/pages/information/RotationChampions.tsx
@@ -17,7 +17,7 @@ export default function RotationChampions() {
       <Heading as="h2" textStyle="t2" fontWeight="bold">
         이번주 로테이션 챔피언
       </Heading>
-      <HStack as="ul" gap="16px">
+      <HStack as="ul" gap="16px" w="1040px" flexWrap="wrap" justifyContent="center">
         {data.data.champions.map((champ) => (
           <VStack key={champ.championId} as="li" gap="4px">
             <Image src={championIconUrl(champ.enName)} alt="" width={80} height={80} css={{ borderRadius: '9999px' }} />


### PR DESCRIPTION
## Summary
로테이션 챔피언이 많을 때 오버플로가 아닌 아래로 나열하도록 디자인을 수정했습니다.

## Describe your changes
- 렌더링 된 모습:
  ![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/c9c1d947-c38c-426f-8c79-10b4c96a6930)
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=1604-31132&mode=dev)
