### PR TITLE
feat: add draft summoner match history page

### DIFF
--- a/src/components/pages/rankings/RankingsTable.tsx
+++ b/src/components/pages/rankings/RankingsTable.tsx
@@ -93,7 +93,7 @@ export default function RankingsTable(props: RankingsTableProps) {
               <Td w="140px" display="flex" gap="8px" alignItems="center" justifyContent="center">
                 <TierImage tier={rank.tierInfo.tier} width={24} height={24} />
                 <Box w="24px" textStyle="t2" fontWeight="bold" color="gray800" textAlign="center">
-                  {shortTierName(rank.summoner.soloTierInfo.tier, rank.summoner.soloTierInfo.division)}
+                  {shortTierName(rank.tierInfo.tier, rank.tierInfo.division)}
                 </Box>
                 <Box w="56px" textStyle="t2" fontWeight="regular" color="gray500">
                   {Intl.NumberFormat().format(rank.tierInfo.lp)}LP

--- a/src/components/pages/rankings/TopThreeCard.tsx
+++ b/src/components/pages/rankings/TopThreeCard.tsx
@@ -96,7 +96,7 @@ export default function TopThreeCard(props: TopThreeCardProps) {
             <HStack gap="4px">
               <TierImage tier={summonerRank.tierInfo.tier} width={24} height={24} />
               <Box w="36px" textStyle="t2" fontWeight="bold" textAlign="center" color="gray800">
-                {shortTierName(summonerRank.summoner.soloTierInfo.tier, summonerRank.summoner.soloTierInfo.division)}
+                {shortTierName(summonerRank.tierInfo.tier, summonerRank.tierInfo.division)}
               </Box>
               <Box textStyle="t2" fontWeight="normal" color="gray500">
                 {Intl.NumberFormat().format(summonerRank.tierInfo.lp)}LP

--- a/src/components/pages/summoners/[summonerId]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerId]/Summoner.tsx
@@ -1,0 +1,35 @@
+import { Flex, HStack, Tab, TabList, TabPanel, TabPanels, Tabs, VStack } from '@chakra-ui/react';
+
+export default function Summoner() {
+  return (
+    <VStack gap="40px" w="1080px" m="40px auto 60px">
+      <HStack gap="12px" w="full">
+        <Flex w="447px" h="264px" bg="white">
+          소환사 카드
+        </Flex>
+        <VStack gap="12px" flex="1">
+          <Flex bg="white" h="112px" w="full">
+            솔로 랭크 정보 카드
+          </Flex>
+          <Flex bg="white" h="140px" w="full">
+            최근 게임 결과 카드
+          </Flex>
+        </VStack>
+      </HStack>
+      <Tabs display="flex" flexDir="column" gap="12px" w="full">
+        <TabList pos="relative" gap="30px" boxShadow="inset 0 -1px 0 0" color="gray300">
+          <Tab>전적 정보</Tab>
+          <Tab>챔피언 정보</Tab>
+          <Tab>인게임</Tab>
+          <Tab>그님티 정보</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>전적 정보</TabPanel>
+          <TabPanel>챔피언 정보</TabPanel>
+          <TabPanel>인게임</TabPanel>
+          <TabPanel>그님티 정보</TabPanel>
+        </TabPanels>
+      </Tabs>
+    </VStack>
+  );
+}

--- a/src/pages/summoners/[summonerId].tsx
+++ b/src/pages/summoners/[summonerId].tsx
@@ -1,0 +1,14 @@
+import Head from 'next/head';
+
+import Summoner from '@/components/pages/summoners/[summonerId]/Summoner';
+
+export default function SummonerRoute() {
+  return (
+    <>
+      <Head>
+        <title>[소환사명] - 게임 전적</title>
+      </Head>
+      <Summoner />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
각자 작업하기 위한 소환사 전적 정보 페이지의 초안을 만들었습니다. 그리고 CI 상에서 에러가 나는 저번 API 동기화 작업때의 잔재들도 수정했습니다.

## Describe your changes
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=2939-11378&mode=dev)
- 렌더링 된 모습:
	![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/f77fff2e-e846-4e3d-8be9-a866b7beb946)


