### PR TITLE
feat: add summoner detail card in summoner page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tanstack/react-query": "^5.17.1",
         "axios": "^1.6.3",
         "constate": "^3.3.2",
+        "dayjs": "^1.11.10",
         "framer-motion": "^10.17.4",
         "next": "^14.0.4",
         "react": "18.2.0",
@@ -6090,6 +6091,11 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tanstack/react-query": "^5.17.1",
     "axios": "^1.6.3",
     "constate": "^3.3.2",
+    "dayjs": "^1.11.10",
     "framer-motion": "^10.17.4",
     "next": "^14.0.4",
     "react": "18.2.0",

--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -237,3 +237,9 @@ export interface ProfileEntry {
   riotDependentInfo: RiotDependentInfo;
   oauthInfos: OauthInfoEntry[];
 }
+
+export interface ApiStatus {
+  message: string;
+  code: number;
+  field: string;
+}

--- a/src/apis/useRenewSummoner.ts
+++ b/src/apis/useRenewSummoner.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query';
+
+import httpRequest from './httpRequest';
+
+import type { ApiStatus } from './types';
+
+interface RenewSummonerOptions {
+  /** 갱신할 소환사 PUUID */
+  puuid: string;
+}
+
+interface RenewSummonerResponse {
+  status: ApiStatus;
+}
+
+async function renewSummoner(options: RenewSummonerOptions) {
+  const res = await httpRequest.post<RenewSummonerResponse>(`/statistics/summoners/${options.puuid}`);
+  return res.data;
+}
+
+export default function useRenewSummoner() {
+  const mutation = useMutation({
+    mutationFn: renewSummoner,
+  });
+
+  return { ...mutation, renewSummoner: mutation.mutate };
+}

--- a/src/apis/utils/fullTierName.ts
+++ b/src/apis/utils/fullTierName.ts
@@ -1,0 +1,16 @@
+import type { Tier } from '@/apis/types';
+
+export default function fullTierName(tier: Tier, division?: number) {
+  switch (tier) {
+    case 'challenger':
+      return 'Challenger';
+    case 'grandmaster':
+      return 'Grand Master';
+    case 'master':
+      return 'Master';
+    case 'UNRANKED':
+      return 'Unranked';
+    default:
+      return `${tier[0].toUpperCase()}${tier.slice(1)} ${division}`;
+  }
+}

--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -1,8 +1,39 @@
-import { Flex, HStack, Tab, TabList, TabPanel, TabPanels, Tabs, VStack } from '@chakra-ui/react';
+import 'dayjs/locale/ko';
+
+import {
+  Box,
+  Button,
+  Flex,
+  HStack,
+  IconButton,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
+import relativeTime from 'dayjs/plugin/relativeTime';
 import Head from 'next/head';
+import Image from 'next/image';
 
 import summonerMatchesInfoQuery from '@/apis/queries/summonerMatchesInfoQuery';
+import useRenewSummoner from '@/apis/useRenewSummoner';
+import fullTierName from '@/apis/utils/fullTierName';
+import profileIconUrl from '@/apis/utils/profileIconUrl';
+import Chat from '@/assets/icons/system/chat.svg';
+import Copy from '@/assets/icons/system/copy.svg';
+import Like from '@/assets/icons/system/like.svg';
+import StatusIndicator from '@/components/common/StatusIndicator';
+import TierImage from '@/components/common/TierImage';
+
+dayjs.locale('ko');
+dayjs.extend(relativeTime);
+dayjs.extend(duration);
 
 interface SummonerProps {
   summonerTagName: string;
@@ -12,6 +43,8 @@ export default function Summoner(props: SummonerProps) {
   const { summonerTagName } = props;
 
   const { data, status } = useQuery(summonerMatchesInfoQuery({ summonerTagName }));
+
+  const { renewSummoner } = useRenewSummoner();
 
   if (status !== 'success') {
     return;
@@ -24,9 +57,112 @@ export default function Summoner(props: SummonerProps) {
       </Head>
       <VStack gap="40px" w="1080px" m="40px auto 60px">
         <HStack gap="12px" w="full">
-          <Flex w="447px" h="264px" bg="white">
-            소환사 카드
-          </Flex>
+          <VStack alignItems="normal" w="447px" h="264px" bg="white" p="20px" gap="12px">
+            <HStack alignItems="normal" gap="24px">
+              <Box pos="relative" width="100px" height="100px">
+                <Image
+                  src={profileIconUrl(data.data.summoner.profileIconId)}
+                  alt=""
+                  fill
+                  css={{ borderRadius: '999px' }}
+                />
+                <Flex
+                  pos="absolute"
+                  bottom={0}
+                  left="50%"
+                  transform="translate(-50%, 50%)"
+                  p="1px 8px 1px 8px"
+                  borderRadius="20px"
+                  bg="gray800"
+                  color="white"
+                  alignItems="center"
+                  justifyContent="center"
+                  textStyle="body"
+                  fontWeight="regular"
+                >
+                  {data.data.summoner.summonerLevel}
+                </Flex>
+              </Box>
+              <VStack alignItems="start">
+                <HStack gap="12px">
+                  <HStack gap="4px">
+                    <Text
+                      textStyle="h2"
+                      fontWeight="bold"
+                      color="gray800"
+                      maxW="230px"
+                      textOverflow="ellipsis"
+                      overflowX="hidden"
+                      whiteSpace="nowrap"
+                    >
+                      {data.data.summoner.summonerName}
+                    </Text>
+                    <IconButton
+                      display="inline-flex"
+                      aria-label="소환사명 복사"
+                      onClick={async () => {
+                        await navigator.clipboard.writeText(
+                          `${data.data.summoner.summonerName}#${data.data.summoner.tagLine}`,
+                        );
+                      }}
+                    >
+                      <Copy width={16} height={16} aria-hidden="true" />
+                    </IconButton>
+                  </HStack>
+                  {/* TODO: API에 유저 활동상태 추가 부탁드린다고 백엔드 분들께 말씀 드려야 함.  */}
+                  <StatusIndicator status="AWAY" />
+                </HStack>
+                <Text color="gray600" textStyle="h3" fontWeight="regular">
+                  #{data.data.summoner.tagLine}
+                </Text>
+                <HStack gap="8px">
+                  <TierImage tier={data.data.summoner.soloTierInfo.tier} width={28} height={28} />
+                  <Text textStyle="h3" color="gray800" fontWeight="bold">
+                    {fullTierName(data.data.summoner.soloTierInfo.tier, data.data.summoner.soloTierInfo.division)}
+                  </Text>
+                  <Text textStyle="h3" fontWeight="regular" color="gray500">
+                    {Intl.NumberFormat().format(data.data.summoner.soloTierInfo.lp)}
+                    LP
+                  </Text>
+                </HStack>
+                <HStack border="1px solid" borderColor="gray400" borderRadius="20px" p="4px 10px 4px 8px" gap="4px">
+                  <Like width={20} height={20} css={(theme) => ({ color: theme.colors.gray600 })} />
+                  <Text textStyle="t2" fontWeight="regular" color="gray700">
+                    {/* TODO: API에 관련 정보 추가해달라고 요청해야함 */}
+                    {Intl.NumberFormat().format(1234)}
+                  </Text>
+                </HStack>
+              </VStack>
+            </HStack>
+            <VStack alignItems="normal" gap="8px">
+              <HStack gap="8px">
+                <Text textStyle="body" fontWeight="regular" color="gray500">
+                  마지막 갱신
+                </Text>{' '}
+                <Text textStyle="body" fontWeight="bold" color="gray500">
+                  {dayjs().from(dayjs(data.data.renewableAfter))}
+                </Text>
+              </HStack>
+              <HStack gap="12px">
+                <Button
+                  size="lg"
+                  variant="unstyled"
+                  bg="black"
+                  color="white"
+                  flex="1 1 0"
+                  onClick={() => {
+                    // TODO: 로딩 처리와 성공 혹은 에러 시 유저에게 피드백 필요
+                    renewSummoner({ puuid: data.data.summoner.puuid });
+                  }}
+                >
+                  전적 갱신
+                </Button>
+                <Button size="lg" variant="default" flex="1 1 0" display="inline-flex" gap="4px">
+                  <Chat width={24} height={24} aria-hidden /> 채팅하기
+                </Button>
+              </HStack>
+            </VStack>
+          </VStack>
           <VStack gap="12px" flex="1">
             <Flex bg="white" h="112px" w="full">
               솔로 랭크 정보 카드


### PR DESCRIPTION
## Summary
소환사 상세 페이지에 소환사 디테일 카드를 추가했습니다.

## Describe your changes
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=2235-10341&mode=design&t=KaxBhDNoUWHfG2T5-4)
- 렌더링 된 모습:
	![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/9017454f-522a-4efb-8101-b9f998b6353e)
