### PR TITLE
feat: add rank cards in summoner page

### DIFF
--- a/src/components/pages/summoners/[summonerTagName]/RankCard.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/RankCard.tsx
@@ -1,0 +1,41 @@
+import { HStack, Text, VStack } from '@chakra-ui/react';
+
+import type { Tier } from '@/apis/types';
+import fullTierName from '@/apis/utils/fullTierName';
+import TierImage from '@/components/common/TierImage';
+
+interface RankCardProps {
+  tierType: 'solo' | 'flex';
+  tier: Tier;
+  division: number;
+  lp: number;
+  rank: number;
+}
+
+export default function RankCard(props: RankCardProps) {
+  const { tierType, tier, division, lp, rank } = props;
+
+  return (
+    <VStack alignItems="normal" bg="white" flex="1 1 0" p="20px" borderRadius="4px" gap="12px">
+      <Text textStyle="t2" fontWeight="regular" color="gray700">
+        {tierType === 'solo' ? '솔로' : '자유'} 랭크
+      </Text>
+      <HStack gap="20px">
+        <TierImage tier={tier} width={40} height={40} />
+        <VStack alignItems="normal" gap="2px">
+          <Text textStyle="t1" fontWeight="bold" color="gray800">
+            {fullTierName(tier, division)}
+          </Text>
+          <HStack gap="8px">
+            <Text textStyle="body" fontWeight="regular" color="gray500">
+              {lp}LP
+            </Text>
+            <Text textStyle="body" fontWeight="regular" color="gray500">
+              랭크 {rank}위
+            </Text>
+          </HStack>
+        </VStack>
+      </HStack>
+    </VStack>
+  );
+}

--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -31,6 +31,8 @@ import Like from '@/assets/icons/system/like.svg';
 import StatusIndicator from '@/components/common/StatusIndicator';
 import TierImage from '@/components/common/TierImage';
 
+import RankCard from './RankCard';
+
 dayjs.locale('ko');
 dayjs.extend(relativeTime);
 dayjs.extend(duration);
@@ -164,9 +166,26 @@ export default function Summoner(props: SummonerProps) {
             </VStack>
           </VStack>
           <VStack gap="12px" flex="1">
-            <Flex bg="white" h="112px" w="full">
-              솔로 랭크 정보 카드
-            </Flex>
+            <HStack gap="12px" h="112px" w="full">
+              <RankCard
+                tierType="solo"
+                tier={data.data.summoner.soloTierInfo.tier}
+                division={data.data.summoner.soloTierInfo.division}
+                lp={data.data.summoner.soloTierInfo.lp}
+                // TODO: API에 순위 정보가 추가 되면 같이 업데이트 필요
+                rank={1}
+              />
+              {data.data.summoner.flexTierInfo !== null && (
+                <RankCard
+                  tierType="flex"
+                  tier={data.data.summoner.flexTierInfo.tier}
+                  division={data.data.summoner.flexTierInfo.division}
+                  lp={data.data.summoner.flexTierInfo.lp}
+                  // TODO: API에 순위 정보가 추가 되면 같이 업데이트 필요
+                  rank={1}
+                />
+              )}
+            </HStack>
             <Flex bg="white" h="140px" w="full">
               최근 게임 결과 카드
             </Flex>


### PR DESCRIPTION
## Summary
소환사 상세 페이지에 랭크 카드들을 추가했습니다.

## Describe your changes
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=2939-11469&mode=design&t=N5bfHuUJ1gdcwl0Q-4)
- 렌더링 된 모습:
	![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/c991bd96-22e7-4a3d-8c74-8d46834a6f5f)
