### PR TITLE
refactor: sync api main page champions table

### DIFF
--- a/src/apis/queries/championsTierQuery.ts
+++ b/src/apis/queries/championsTierQuery.ts
@@ -2,19 +2,19 @@ import { queryOptions } from '@tanstack/react-query';
 
 import request from '../httpRequest';
 
-import type { ChampionTierDto, Position, PositionFilter, Tier } from '../types';
+import type { ChampionTierDto, Position, Tier } from '../types';
 
 interface ChampionsTierResponse {
   data: {
+    results: { position: Position; champions: ChampionTierDto[] }[];
     version: string;
-    position: Position;
-    champions: ChampionTierDto[];
   };
 }
 
 interface Options {
-  position: PositionFilter;
+  /** 검색하려는 티어대 정보,만약 master를 선택할 경우, 마스터 이상에서 이루어진 게임 정보를 바탕으로 한 챔피언 요약 정보 조회 */
   tier?: Tier;
+  /** true로 지정할 경우에 포지션 내에서 score가 가장 높은 상위 5개의 챔피언 티어 정보만 조회 */
   brief?: boolean;
 }
 
@@ -22,7 +22,7 @@ const championsTierQuery = (options: Options) =>
   queryOptions({
     queryKey: ['rankTiers', options],
     async queryFn() {
-      const res = await request.get<ChampionsTierResponse>('/statistics/champion/stats/tier', {
+      const res = await request.get<ChampionsTierResponse>('/statistics/champion/stats', {
         params: options,
       });
       return res.data;

--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -139,6 +139,7 @@ export interface ChampionDto {
 
 export interface ChampionTierDto {
   championId: number;
+  championName: string;
   winRate: number;
   pickRate: number;
   banRate: number;

--- a/src/components/pages/main/ChampionsTable.tsx
+++ b/src/components/pages/main/ChampionsTable.tsx
@@ -5,28 +5,18 @@ import Image from 'next/image';
 import championIdEnNameMap from '@/apis/constants/championIdEnNameMap';
 import championIdKrNameMap from '@/apis/constants/championIdKrNameMap';
 import championsTierQuery from '@/apis/queries/championsTierQuery';
-import type { Position } from '@/apis/types';
+import type { ChampionTierDto } from '@/apis/types';
 import championIconUrl from '@/apis/utils/championIconUrl';
 import ChampionTierBadge from '@/components/common/ChampionTierBadge';
 
 import * as style from './ChampionsTable.style';
 
 interface ChampionTabPanelProps {
-  position: Position;
+  champions: ChampionTierDto[];
 }
 
-/*
- * TODO: 후에 API 요청 받아올 때는 activePosition도 하나 받아가지고
- * position !== activePosition과 다르다면 API 요청을 하지 않도록 설정
- */
-
 function ChampionTabPanel(props: ChampionTabPanelProps) {
-  const { position } = props;
-  const { data, status } = useQuery(championsTierQuery({ position, brief: true }));
-
-  if (status !== 'success') {
-    return;
-  }
+  const { champions } = props;
 
   return (
     <TabPanel>
@@ -41,7 +31,7 @@ function ChampionTabPanel(props: ChampionTabPanelProps) {
           </tr>
         </thead>
         <tbody css={style.tableHeadBody}>
-          {data.data.champions.map((champion, i) => (
+          {champions.slice(0, 5).map((champion, i) => (
             <tr key={champion.championId} css={style.tableRow}>
               <td css={style.championRanking}>{i + 1}</td>
               <td css={style.championNameAndImage}>
@@ -67,9 +57,19 @@ function ChampionTabPanel(props: ChampionTabPanelProps) {
   );
 }
 
-const positions: Position[] = ['TOP', 'JUNGLE', 'MIDDLE', 'BOTTOM', 'UTILITY'];
-
 export default function ChampionsTable() {
+  const { data, status } = useQuery(championsTierQuery({ brief: true }));
+
+  if (status !== 'success') {
+    return;
+  }
+
+  const top = data.data.results.find((result) => result.position === 'TOP')!;
+  const jungle = data.data.results.find((result) => result.position === 'JUNGLE')!;
+  const middle = data.data.results.find((result) => result.position === 'MIDDLE')!;
+  const bottom = data.data.results.find((result) => result.position === 'BOTTOM')!;
+  const utility = data.data.results.find((result) => result.position === 'UTILITY')!;
+
   return (
     <article css={style.championsRoot}>
       <Tabs>
@@ -86,8 +86,8 @@ export default function ChampionsTable() {
           </TabList>
         </header>
         <TabPanels>
-          {positions.map((position) => (
-            <ChampionTabPanel key={position} position={position} />
+          {[top, jungle, middle, bottom, utility].map((result) => (
+            <ChampionTabPanel key={result.position} champions={result.champions} />
           ))}
         </TabPanels>
       </Tabs>


### PR DESCRIPTION
## Summary
메인 페이지의 챔피언 테이블쪽의 API를 현재 API에 맞게 조정했습니다.

## Describe your changes
렌더링 된 모습:
![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/e33c3ca2-6983-467a-8db6-a86c61635e48)
