### PR TITLE
feat: integrate api recent matches

### DIFF
--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -251,6 +251,8 @@ export interface ChampionSummaryDto {
   isPerfect: boolean;
 }
 
+export type LaneSummaryDto = Record<Position, number>;
+
 export interface MatchSummaryDto {
   plays: number;
   wins: number;
@@ -259,6 +261,7 @@ export interface MatchSummaryDto {
   avgKda: number;
   isPerfect: boolean;
   championSummary: ChampionSummaryDto[];
+  laneSummary: LaneSummaryDto;
 }
 
 export interface SummonerPlayDto {

--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -242,6 +242,7 @@ export interface ProfileEntry {
 }
 
 export interface ChampionSummaryDto {
+  championId: number;
   plays: number;
   wins: number;
   defeats: number;

--- a/src/components/pages/summoners/[summonerTagName]/LanePlaysGraph.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/LanePlaysGraph.tsx
@@ -1,8 +1,35 @@
 import { Box, HStack, VStack } from '@chakra-ui/react';
+import { createContext, useContext } from 'react';
 
 import type { LaneSummaryDto } from '@/apis/types';
 import PositionImage from '@/components/common/position-image/PositionImage';
 import proportionalValue from '@/utils/proportionalValue';
+
+const VERTICAL_BAR_HEIGHT_PX = 48;
+
+const TotalLanePlaysContext = createContext<number>(0);
+
+interface VerticalBarProps {
+  lanePlays: number;
+}
+
+function VerticalBar(props: VerticalBarProps) {
+  const { lanePlays } = props;
+
+  const totalLanePlays = useContext(TotalLanePlaysContext);
+
+  return (
+    <Box w="12px" h={`${VERTICAL_BAR_HEIGHT_PX}px`} bg="gray200" pos="relative">
+      <Box
+        w="full"
+        bg="red800"
+        h={`${proportionalValue(totalLanePlays, lanePlays, VERTICAL_BAR_HEIGHT_PX)}px`}
+        pos="absolute"
+        bottom="0"
+      />
+    </Box>
+  );
+}
 
 interface LanePlaysGraphProps {
   laneSummary: LaneSummaryDto;
@@ -16,51 +43,13 @@ export default function LanePlaysGraph(props: LanePlaysGraphProps) {
   return (
     <VStack gap={0}>
       <HStack gap="20px">
-        <Box w="12px" h="48px" bg="gray200" pos="relative">
-          <Box
-            w="full"
-            bg="red800"
-            h={`${proportionalValue(totalLanePlays, laneSummary.TOP, 48)}px`}
-            pos="absolute"
-            bottom="0"
-          />
-        </Box>
-        <Box w="12px" h="48px" bg="gray200" pos="relative">
-          <Box
-            w="full"
-            bg="red800"
-            h={`${proportionalValue(totalLanePlays, laneSummary.JUNGLE, 48)}px`}
-            pos="absolute"
-            bottom="0"
-          />
-        </Box>
-        <Box w="12px" h="48px" bg="gray200" pos="relative">
-          <Box
-            w="full"
-            bg="red800"
-            h={`${proportionalValue(totalLanePlays, laneSummary.MIDDLE, 48)}px`}
-            pos="absolute"
-            bottom="0"
-          />
-        </Box>
-        <Box w="12px" h="48px" bg="gray200" pos="relative">
-          <Box
-            w="full"
-            bg="red800"
-            h={`${proportionalValue(totalLanePlays, laneSummary.BOTTOM, 48)}px`}
-            pos="absolute"
-            bottom="0"
-          />
-        </Box>
-        <Box w="12px" h="48px" bg="gray200" pos="relative">
-          <Box
-            w="full"
-            bg="red800"
-            h={`${proportionalValue(totalLanePlays, laneSummary.UTILITY, 48)}px`}
-            pos="absolute"
-            bottom="0"
-          />
-        </Box>
+        <TotalLanePlaysContext.Provider value={totalLanePlays}>
+          <VerticalBar lanePlays={laneSummary.TOP} />
+          <VerticalBar lanePlays={laneSummary.JUNGLE} />
+          <VerticalBar lanePlays={laneSummary.MIDDLE} />
+          <VerticalBar lanePlays={laneSummary.BOTTOM} />
+          <VerticalBar lanePlays={laneSummary.UTILITY} />
+        </TotalLanePlaysContext.Provider>
       </HStack>
       <HStack gap="16px" pt="4px" px="8px" borderTop="1px solid" borderColor="gray500">
         <PositionImage position="TOP" width={16} height={16} />

--- a/src/components/pages/summoners/[summonerTagName]/LanePlaysGraph.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/LanePlaysGraph.tsx
@@ -1,27 +1,65 @@
 import { Box, HStack, VStack } from '@chakra-ui/react';
 
+import type { LaneSummaryDto } from '@/apis/types';
 import PositionImage from '@/components/common/position-image/PositionImage';
 import proportionalValue from '@/utils/proportionalValue';
 
-export default function LanePlaysGraph() {
+interface LanePlaysGraphProps {
+  laneSummary: LaneSummaryDto;
+}
+
+export default function LanePlaysGraph(props: LanePlaysGraphProps) {
+  const { laneSummary } = props;
+
+  const totalLanePlays = Object.values(laneSummary).reduce((count, sum) => count + sum);
+
   return (
     <VStack gap={0}>
       <HStack gap="20px">
-        {/* TODO: 이 부분 백엔드에서 라인별 데이터 보내달라고 해야 함 */}
         <Box w="12px" h="48px" bg="gray200" pos="relative">
-          <Box w="full" bg="red800" h={`${proportionalValue(100, 0.5 * 100, 48)}px`} pos="absolute" bottom="0" />
+          <Box
+            w="full"
+            bg="red800"
+            h={`${proportionalValue(totalLanePlays, laneSummary.TOP, 48)}px`}
+            pos="absolute"
+            bottom="0"
+          />
         </Box>
         <Box w="12px" h="48px" bg="gray200" pos="relative">
-          <Box w="full" bg="red800" h={`${proportionalValue(100, 0.2 * 100, 48)}px`} pos="absolute" bottom="0" />
+          <Box
+            w="full"
+            bg="red800"
+            h={`${proportionalValue(totalLanePlays, laneSummary.JUNGLE, 48)}px`}
+            pos="absolute"
+            bottom="0"
+          />
         </Box>
         <Box w="12px" h="48px" bg="gray200" pos="relative">
-          <Box w="full" bg="red800" h={`${proportionalValue(100, 0.9 * 100, 48)}px`} pos="absolute" bottom="0" />
+          <Box
+            w="full"
+            bg="red800"
+            h={`${proportionalValue(totalLanePlays, laneSummary.MIDDLE, 48)}px`}
+            pos="absolute"
+            bottom="0"
+          />
         </Box>
         <Box w="12px" h="48px" bg="gray200" pos="relative">
-          <Box w="full" bg="red800" h={`${proportionalValue(100, 0.4 * 100, 48)}px`} pos="absolute" bottom="0" />
+          <Box
+            w="full"
+            bg="red800"
+            h={`${proportionalValue(totalLanePlays, laneSummary.BOTTOM, 48)}px`}
+            pos="absolute"
+            bottom="0"
+          />
         </Box>
         <Box w="12px" h="48px" bg="gray200" pos="relative">
-          <Box w="full" bg="red800" h={`${proportionalValue(100, 0.01 * 100, 48)}px`} pos="absolute" bottom="0" />
+          <Box
+            w="full"
+            bg="red800"
+            h={`${proportionalValue(totalLanePlays, laneSummary.UTILITY, 48)}px`}
+            pos="absolute"
+            bottom="0"
+          />
         </Box>
       </HStack>
       <HStack gap="16px" pt="4px" px="8px" borderTop="1px solid" borderColor="gray500">

--- a/src/components/pages/summoners/[summonerTagName]/LanePlaysGraph.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/LanePlaysGraph.tsx
@@ -1,0 +1,36 @@
+import { Box, HStack, VStack } from '@chakra-ui/react';
+
+import PositionImage from '@/components/common/position-image/PositionImage';
+import proportionalValue from '@/utils/proportionalValue';
+
+export default function LanePlaysGraph() {
+  return (
+    <VStack gap={0}>
+      <HStack gap="20px">
+        {/* TODO: 이 부분 백엔드에서 라인별 데이터 보내달라고 해야 함 */}
+        <Box w="12px" h="48px" bg="gray200" pos="relative">
+          <Box w="full" bg="red800" h={`${proportionalValue(100, 0.5 * 100, 48)}px`} pos="absolute" bottom="0" />
+        </Box>
+        <Box w="12px" h="48px" bg="gray200" pos="relative">
+          <Box w="full" bg="red800" h={`${proportionalValue(100, 0.2 * 100, 48)}px`} pos="absolute" bottom="0" />
+        </Box>
+        <Box w="12px" h="48px" bg="gray200" pos="relative">
+          <Box w="full" bg="red800" h={`${proportionalValue(100, 0.9 * 100, 48)}px`} pos="absolute" bottom="0" />
+        </Box>
+        <Box w="12px" h="48px" bg="gray200" pos="relative">
+          <Box w="full" bg="red800" h={`${proportionalValue(100, 0.4 * 100, 48)}px`} pos="absolute" bottom="0" />
+        </Box>
+        <Box w="12px" h="48px" bg="gray200" pos="relative">
+          <Box w="full" bg="red800" h={`${proportionalValue(100, 0.01 * 100, 48)}px`} pos="absolute" bottom="0" />
+        </Box>
+      </HStack>
+      <HStack gap="16px" pt="4px" px="8px" borderTop="1px solid" borderColor="gray500">
+        <PositionImage position="TOP" width={16} height={16} />
+        <PositionImage position="JUNGLE" width={16} height={16} />
+        <PositionImage position="MIDDLE" width={16} height={16} />
+        <PositionImage position="BOTTOM" width={16} height={16} />
+        <PositionImage position="UTILITY" width={16} height={16} />
+      </HStack>
+    </VStack>
+  );
+}

--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -31,12 +31,11 @@ import profileIconUrl from '@/apis/utils/profileIconUrl';
 import Chat from '@/assets/icons/system/chat.svg';
 import Copy from '@/assets/icons/system/copy.svg';
 import Like from '@/assets/icons/system/like.svg';
-import PositionImage from '@/components/common/position-image/PositionImage';
 import StatusIndicator from '@/components/common/StatusIndicator';
 import TierImage from '@/components/common/TierImage';
-import proportionalValue from '@/utils/proportionalValue';
 
 import CurrentGameTab from './CurrentGameTab/CurrentGameTab';
+import LanePlaysGraph from './LanePlaysGraph';
 import RankCard from './RankCard';
 
 dayjs.locale('ko');
@@ -231,63 +230,7 @@ export default function Summoner(props: SummonerProps) {
                     ))}
                   </HStack>
                 </VStack>
-                <VStack gap={0}>
-                  <HStack gap="20px">
-                    {/* TODO: 이 부분 백엔드에서 라인별 데이터 보내달라고 해야 함 */}
-                    <Box w="12px" h="48px" bg="gray200" pos="relative">
-                      <Box
-                        w="full"
-                        bg="red800"
-                        h={`${proportionalValue(100, 0.5 * 100, 48)}px`}
-                        pos="absolute"
-                        bottom="0"
-                      />
-                    </Box>
-                    <Box w="12px" h="48px" bg="gray200" pos="relative">
-                      <Box
-                        w="full"
-                        bg="red800"
-                        h={`${proportionalValue(100, 0.2 * 100, 48)}px`}
-                        pos="absolute"
-                        bottom="0"
-                      />
-                    </Box>
-                    <Box w="12px" h="48px" bg="gray200" pos="relative">
-                      <Box
-                        w="full"
-                        bg="red800"
-                        h={`${proportionalValue(100, 0.9 * 100, 48)}px`}
-                        pos="absolute"
-                        bottom="0"
-                      />
-                    </Box>
-                    <Box w="12px" h="48px" bg="gray200" pos="relative">
-                      <Box
-                        w="full"
-                        bg="red800"
-                        h={`${proportionalValue(100, 0.4 * 100, 48)}px`}
-                        pos="absolute"
-                        bottom="0"
-                      />
-                    </Box>
-                    <Box w="12px" h="48px" bg="gray200" pos="relative">
-                      <Box
-                        w="full"
-                        bg="red800"
-                        h={`${proportionalValue(100, 0.01 * 100, 48)}px`}
-                        pos="absolute"
-                        bottom="0"
-                      />
-                    </Box>
-                  </HStack>
-                  <HStack gap="16px" pt="4px" px="8px" borderTop="1px solid" borderColor="gray500">
-                    <PositionImage position="TOP" width={16} height={16} />
-                    <PositionImage position="JUNGLE" width={16} height={16} />
-                    <PositionImage position="MIDDLE" width={16} height={16} />
-                    <PositionImage position="BOTTOM" width={16} height={16} />
-                    <PositionImage position="UTILITY" width={16} height={16} />
-                  </HStack>
-                </VStack>
+                <LanePlaysGraph />
               </HStack>
             </VStack>
           </VStack>

--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -204,7 +204,9 @@ export default function Summoner(props: SummonerProps) {
                       패
                     </Text>
                     <Text textStyle="t2" fontWeight="bold" color="green800">
-                      {data.data.matchSummary.avgKda.toFixed(2)} 평점
+                      {data.data.matchSummary.isPerfect
+                        ? 'Perfect'
+                        : `${data.data.matchSummary.avgKda.toFixed(2)} 평점`}
                     </Text>
                   </HStack>
                   <HStack gap="20px">

--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -230,7 +230,7 @@ export default function Summoner(props: SummonerProps) {
                     ))}
                   </HStack>
                 </VStack>
-                <LanePlaysGraph />
+                <LanePlaysGraph laneSummary={data.data.matchSummary.laneSummary} />
               </HStack>
             </VStack>
           </VStack>

--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -211,13 +211,12 @@ export default function Summoner(props: SummonerProps) {
                   </HStack>
                   <HStack gap="20px">
                     {data.data.matchSummary.championSummary.map((champion) => (
-                      // TODO: 백엔드 분들 께 챔피언 서머리에 챔피언 아이디 넘겨 달라고 해야함
                       <HStack key={champion.avgKda} gap="12px" alignItems="normal">
                         <Image
-                          src={championIconUrl(championIdEnNameMap[10])}
+                          src={championIconUrl(championIdEnNameMap[champion.championId])}
                           width={36}
                           height={36}
-                          alt={championIdKrNameMap[10]}
+                          alt={championIdKrNameMap[champion.championId]}
                           css={{ borderRadius: '999px' }}
                         />
                         <VStack alignItems="normal" gap={0}>


### PR DESCRIPTION
## Summary
소환사 페이지에 최근 게임 결과쪽 API를 연동시켰습니다.

## Describe your changes
- 최근 플레이한 챔피언의 이미지를 API에서 받아온 값 기반으로 보여줍니다.
- 최근 플레이한 라인 카운팅 그래프를 API에서 받아온 값 기반으로 보여줍니다.
- 연동 전:
	![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/870ccc99-ce88-4ce8-a8b4-6f121f6e2e87)
	연동 후:
	![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/f98b09fb-409c-4454-a3b9-59aea24b1a85)
