### PR TITLE
fix: observer disconnect - 중복 조회 방지

### DIFF
--- a/src/pages/duo.tsx
+++ b/src/pages/duo.tsx
@@ -40,7 +40,9 @@ export default function Duo() {
       if (observer.current) observer.current.disconnect();
       observer.current = new IntersectionObserver((entries) => {
         if (entries[0].isIntersecting && hasNextPage) {
-          fetchNextPage();
+          fetchNextPage().then(() => {
+            observer.current?.disconnect();
+          });
         }
       });
       if (node) observer.current.observe(node);


### PR DESCRIPTION
## Summary

- infinite scroll 시 중복조회 발생하는 문제 수정

## Describe your changes

- lastSummonerRef에서 조회가 발생했다면 옵저버 연결을 끊어 다시 조회가 발생하는 것을 막았습니다
