### PR TITLE
ci: run only one deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches: ['dev']
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml


### PR DESCRIPTION
## Summary
배포 충돌을 막기 위해 기존에 배포 작업이 실행 중일 때 새로운 배포가 시작 되면 기존의 배포 작업을 취소하고 새로운 배포만을 실행합니다.
