### PR TITLE
fix: 로그인상태가 아닐 때 chat client deactivate

### DIFF
--- a/src/contexts/ChatContext.ts
+++ b/src/contexts/ChatContext.ts
@@ -101,6 +101,9 @@ export const [ChatContextProvider, useChatContext] = constate(() => {
   };
 
   useEffect(() => {
+    if (myInfo === undefined && chatClient !== null) {
+      chatClient.deactivate();
+    }
     if (myInfo !== undefined) {
       const currentUserId = myInfo.id;
       if (currentUserId) {

--- a/src/contexts/ChatContext.ts
+++ b/src/contexts/ChatContext.ts
@@ -101,8 +101,8 @@ export const [ChatContextProvider, useChatContext] = constate(() => {
   };
 
   useEffect(() => {
-    if (myInfo === undefined && chatClient !== null) {
-      chatClient.deactivate();
+    if (myInfo === undefined) {
+      chatClient?.deactivate();
     }
     if (myInfo !== undefined) {
       const currentUserId = myInfo.id;
@@ -130,7 +130,7 @@ export const [ChatContextProvider, useChatContext] = constate(() => {
         setChatClient(client);
       }
     }
-  }, [myInfo]);
+  }, [myInfo, chatClient]);
 
   useEffect(() => {
     activateChatUserIds.forEach((userId) => {


### PR DESCRIPTION
## Summary

- 로그인상태가 아닐 때 chat client deactivate

## Describe your changes

- 로그인이 자동으로 풀렸을 때 stomp 커넥션이 끊어져 앱이 크래시나는 부분을 막는 조치입니다
