### PR TITLE
feat: always shows flex tier info

### DIFF
--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -89,6 +89,8 @@ export interface SummonerTierDto {
   mostChampionIds: number[];
   /** 최근 20게임 자주 가는 포지션 */
   mostLanes: Position[];
+  /** 솔로랭크 순위정보로, 마스터 이상 유저에 한해서만 해당 필드가 노출됩니다. */
+  rank?: number;
 }
 
 export interface SummonerRankDto {

--- a/src/components/pages/summoners/[summonerTagName]/RankCard.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/RankCard.tsx
@@ -1,19 +1,17 @@
 import { HStack, Text, VStack } from '@chakra-ui/react';
 
-import type { Tier } from '@/apis/types';
+import type { SummonerTierDto } from '@/apis/types';
 import fullTierName from '@/apis/utils/fullTierName';
 import TierImage from '@/components/common/TierImage';
 
 interface RankCardProps {
   tierType: 'solo' | 'flex';
-  tier: Tier;
-  division: number;
-  lp: number;
-  rank: number;
+  tierInfo: SummonerTierDto | null;
 }
 
 export default function RankCard(props: RankCardProps) {
-  const { tierType, tier, division, lp, rank } = props;
+  const { tierType, tierInfo } = props;
+  const { tier = 'unknown', division, lp } = tierInfo ?? {};
 
   return (
     <VStack alignItems="normal" bg="white" flex="1 1 0" p="20px" borderRadius="4px" gap="12px">
@@ -26,14 +24,21 @@ export default function RankCard(props: RankCardProps) {
           <Text textStyle="t1" fontWeight="bold" color="gray800">
             {fullTierName(tier, division)}
           </Text>
-          <HStack gap="8px">
+          {tier === 'unknown' ? (
             <Text textStyle="body" fontWeight="regular" color="gray500">
-              {lp}LP
+              -
             </Text>
-            <Text textStyle="body" fontWeight="regular" color="gray500">
-              랭크 {rank}위
-            </Text>
-          </HStack>
+          ) : (
+            <HStack gap="8px">
+              <Text textStyle="body" fontWeight="regular" color="gray500">
+                {lp}LP
+              </Text>
+              <Text textStyle="body" fontWeight="regular" color="gray500">
+                {/* TODO: API에 순위 정보가 추가 되면 같이 업데이트 필요 */}
+                랭크 {1}위
+              </Text>
+            </HStack>
+          )}
         </VStack>
       </HStack>
     </VStack>

--- a/src/components/pages/summoners/[summonerTagName]/RankCard.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/RankCard.tsx
@@ -11,7 +11,7 @@ interface RankCardProps {
 
 export default function RankCard(props: RankCardProps) {
   const { tierType, tierInfo } = props;
-  const { tier = 'unknown', division, lp } = tierInfo ?? {};
+  const { tier = 'unknown', division, lp, rank } = tierInfo ?? {};
 
   return (
     <VStack alignItems="normal" bg="white" flex="1 1 0" p="20px" borderRadius="4px" gap="12px">
@@ -33,10 +33,11 @@ export default function RankCard(props: RankCardProps) {
               <Text textStyle="body" fontWeight="regular" color="gray500">
                 {lp}LP
               </Text>
-              <Text textStyle="body" fontWeight="regular" color="gray500">
-                {/* TODO: API에 순위 정보가 추가 되면 같이 업데이트 필요 */}
-                랭크 {1}위
-              </Text>
+              {rank !== undefined && (
+                <Text textStyle="body" fontWeight="regular" color="gray500">
+                  랭크 {rank}위
+                </Text>
+              )}
             </HStack>
           )}
         </VStack>

--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -175,24 +175,8 @@ export default function Summoner(props: SummonerProps) {
           </VStack>
           <VStack gap="12px" flex="1">
             <HStack gap="12px" h="112px" w="full">
-              <RankCard
-                tierType="solo"
-                tier={data.data.summoner.soloTierInfo.tier}
-                division={data.data.summoner.soloTierInfo.division}
-                lp={data.data.summoner.soloTierInfo.lp}
-                // TODO: API에 순위 정보가 추가 되면 같이 업데이트 필요
-                rank={1}
-              />
-              {data.data.summoner.flexTierInfo !== null && (
-                <RankCard
-                  tierType="flex"
-                  tier={data.data.summoner.flexTierInfo.tier}
-                  division={data.data.summoner.flexTierInfo.division}
-                  lp={data.data.summoner.flexTierInfo.lp}
-                  // TODO: API에 순위 정보가 추가 되면 같이 업데이트 필요
-                  rank={1}
-                />
-              )}
+              <RankCard tierType="solo" tierInfo={data.data.summoner.soloTierInfo} />
+              <RankCard tierType="flex" tierInfo={data.data.summoner.flexTierInfo} />
             </HStack>
             <VStack alignItems="normal" gap="12px" bg="white" h="140px" w="full" p="20px" borderRadius="4px">
               <Text textStyle="t2" fontWeight="regular" color="gray700">


### PR DESCRIPTION
## Summary
자유랭크 정보가 없을 때도 자유랭크 카드가 보이게 설정하고 랭크 순위 정보를 추가했습니다.

## Describe your changes
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=2236-80194&mode=design&t=ZyYkGig2tun84Nri-4)
- 렌더링 된 모습:
	![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/2689c261-bfc4-4f85-b0f8-b077caeb0d81)
