### PR TITLE
feat: add suffix unit for BE and RP

### DIFF
--- a/src/components/pages/information/OnSaleCard.tsx
+++ b/src/components/pages/information/OnSaleCard.tsx
@@ -39,8 +39,15 @@ export default function OnSaleCard(props: OnSaleCardProps) {
           -{Math.floor(discountedRate * 100)}%
         </Center>
       </Box>
-      <HStack w="352px" px="12px" justifyContent="space-between" gap="12px">
-        <Box textStyle="t1" fontWeight="bold">
+      <HStack w="352px" px="12px" justifyContent="space-between" gap="12px" whiteSpace="nowrap">
+        <Box
+          textStyle="t1"
+          fontWeight="bold"
+          color="gray800"
+          overflow="hidden"
+          whiteSpace="nowrap"
+          textOverflow="ellipsis"
+        >
           {name}
         </Box>
         <HStack gap="8px">
@@ -52,7 +59,7 @@ export default function OnSaleCard(props: OnSaleCardProps) {
               <Rp width={22} height={22} />
             </Flex>
             <Box textStyle="t1" fontWeight="bold" color="gray800">
-              {discountedRp}
+              {discountedRp}RP
             </Box>
           </HStack>
           {originIp !== undefined ? (
@@ -61,7 +68,7 @@ export default function OnSaleCard(props: OnSaleCardProps) {
                 <Ip width={22} height={22} />
               </Flex>
               <Box textStyle="t1" fontWeight="bold" color="gray800">
-                {originIp}
+                {originIp}BE
               </Box>
             </HStack>
           ) : null}


### PR DESCRIPTION
## Summary
할인 페이지에서 BE와 RP앞에 Unit 접두사를 붙였습니다.

## Describe your changes
- 현재 피그마의 모습과 렌더링 된 모습이 조금 다른데 [이 댓글](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe?node-id=1604:31195&mode=design#725668342)에서 결정된 대로 수정했습니다.
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=1604-30737&mode=design&t=koir1kFMP5srnL9b-4)
- 렌더링 된 모습: 
	![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/45777dd7-446a-4694-817d-3d792f5f5626)
