### PR TITLE
feat: add search summoner in main page

### DIFF
--- a/src/apis/queries/summonerAutoCompleteQuery.ts
+++ b/src/apis/queries/summonerAutoCompleteQuery.ts
@@ -1,0 +1,32 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import httpRequest from '../httpRequest';
+
+import type { SummonerDto } from '../types';
+
+export interface SummonerAutoCompleteResponse {
+  data: {
+    keyword: string;
+    matched: number;
+    summoners: SummonerDto[];
+  };
+}
+
+interface Options {
+  keyword: string;
+}
+
+const summonerAutoCompleteQuery = (options: Options) =>
+  queryOptions({
+    queryKey: ['summonerAutoComplete', options],
+    async queryFn() {
+      const res = await httpRequest.get<SummonerAutoCompleteResponse>('/statistics/summoners/autocomplete', {
+        params: {
+          keyword: options.keyword,
+        },
+      });
+      return res.data;
+    },
+  });
+
+export default summonerAutoCompleteQuery;

--- a/src/components/pages/main/search/Search.tsx
+++ b/src/components/pages/main/search/Search.tsx
@@ -1,21 +1,26 @@
 import { Box, HStack, IconButton, Input, Tab, TabList, TabPanel, TabPanels, Tabs, Text } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
 import { useState, type FormEventHandler } from 'react';
 
 import SearchIcon from '@/assets/icons/system/search.svg';
 
 import FavoriteSummonersTab from './FavoriteSummonersTab';
 import RecentSearchTab from './RecentSearchesTab';
+import SearchList from './SearchList';
 
 import type { BoxProps } from '@chakra-ui/react';
 
 export interface SearchProps extends Omit<BoxProps, 'children'> {}
 
 export default function Search(props: SearchProps) {
-  const [searchText, setSearchText] = useState('');
+  const [searchKeyword, setSearchKeyword] = useState('');
   const [searchPopState, setSearchPopState] = useState<'hidden' | 'recent-favorite' | 'search'>('hidden');
+
+  const router = useRouter();
 
   const handleSubmit: FormEventHandler = (event) => {
     event.preventDefault();
+    router.push(`/summoners/${encodeURIComponent(searchKeyword.replaceAll('#', '-'))}`);
   };
 
   return (
@@ -46,9 +51,9 @@ export default function Search(props: SearchProps) {
         <HStack as="form" onSubmit={handleSubmit} alignItems="center" gap="12px" flex="1 0 0">
           <Input
             type="search"
-            value={searchText}
+            value={searchKeyword}
             onChange={(event) => {
-              setSearchText(event.target.value);
+              setSearchKeyword(event.target.value);
               if (event.target.value.length > 0) {
                 setSearchPopState('search');
               } else {
@@ -72,22 +77,34 @@ export default function Search(props: SearchProps) {
           </IconButton>
         </HStack>
       </HStack>
-      {searchPopState === 'recent-favorite' && (
-        <Tabs variant="mainSearch" w="420px" pos="absolute" top="calc(100% + 4px)" left="0" zIndex="dropdown">
-          <TabList>
-            <Tab w="210px">최근 검색</Tab>
-            <Tab w="210px">즐겨찾기</Tab>
-          </TabList>
-          <TabPanels>
-            <TabPanel>
-              <RecentSearchTab />
-            </TabPanel>
-            <TabPanel>
-              <FavoriteSummonersTab />
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
-      )}
+      <Box
+        w="420px"
+        pos="absolute"
+        top="calc(100% + 4px)"
+        left="0"
+        zIndex="dropdown"
+        bg="white"
+        boxShadow="0px 4px 6px 0px rgb(17 17 17 / .1)"
+        borderRadius="8px"
+      >
+        {searchPopState === 'recent-favorite' && (
+          <Tabs variant="mainSearch">
+            <TabList>
+              <Tab w="210px">최근 검색</Tab>
+              <Tab w="210px">즐겨찾기</Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel>
+                <RecentSearchTab />
+              </TabPanel>
+              <TabPanel>
+                <FavoriteSummonersTab />
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        )}
+        {searchPopState === 'search' && <SearchList keyword={searchKeyword} />}
+      </Box>
     </Box>
   );
 }

--- a/src/components/pages/main/search/SearchList.tsx
+++ b/src/components/pages/main/search/SearchList.tsx
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+
+import summonerAutoCompleteQuery, { type SummonerAutoCompleteResponse } from '@/apis/queries/summonerAutoCompleteQuery';
+
+import SearchPopBody from './SearchPopBody';
+
+const summonerAutoCompleteToSearchPopRowItems = (data: SummonerAutoCompleteResponse) =>
+  data.data.summoners.map((summoner) => ({
+    puuid: summoner.puuid,
+    summonerName: summoner.summonerName,
+    tagLine: summoner.tagLine,
+    profileIconId: summoner.profileIconId,
+    isVerified: false,
+  }));
+
+interface SearchListProps {
+  keyword: string;
+}
+
+export default function SearchList(props: SearchListProps) {
+  const { keyword } = props;
+
+  const { data: items, status } = useQuery({
+    ...summonerAutoCompleteQuery({ keyword }),
+    select: summonerAutoCompleteToSearchPopRowItems,
+  });
+
+  if (status !== 'success') {
+    return;
+  }
+
+  return <SearchPopBody items={items} />;
+}

--- a/src/components/pages/main/search/SearchPopBody.tsx
+++ b/src/components/pages/main/search/SearchPopBody.tsx
@@ -4,7 +4,7 @@ import SearchPopRow, { type SearchPopRowItem } from './SearchPopRow';
 
 export interface SearchPopBodyProps {
   items: SearchPopRowItem[];
-  textWhenEmpty: string;
+  textWhenEmpty?: string;
   onXButtonClick?: (puuid: string) => void;
 }
 
@@ -12,6 +12,10 @@ export default function SearchPopBody(props: SearchPopBodyProps) {
   const { textWhenEmpty, items, onXButtonClick } = props;
 
   if (items.length === 0) {
+    if (textWhenEmpty === undefined) {
+      return null;
+    }
+
     return (
       <Center h="180px">
         <Text textStyle="t2" fontWeight="regular" color="gray500">

--- a/src/styles/theme/components/tabs.ts
+++ b/src/styles/theme/components/tabs.ts
@@ -20,10 +20,6 @@ const tabVariant = helpers.definePartsStyle({
 });
 
 const mainSearchTabVariant = helpers.definePartsStyle({
-  root: {
-    borderRadius: '8px',
-    boxShadow: '0px 4px 6px 0px rgb(17 17 17 / .1)',
-  },
   tab: {
     bg: 'gray200',
     p: '12px 20px',
@@ -42,11 +38,6 @@ const mainSearchTabVariant = helpers.definePartsStyle({
       bg: 'white',
       color: 'gray800',
     },
-  },
-
-  tabpanels: {
-    bg: 'white',
-    borderBottomRadius: '8px',
   },
 });
 


### PR DESCRIPTION
## Summary
메인 페이지에 검색 기능을 추가했습니다.

## Describe your changes
- 피그마에는 border가 있긴한데 다른 최근 검색, 즐겨찾기에는 없어서 여기에만 넣으면 이상해 보여 일단 없이 구현했습니다. 후에 지적이 들어오면 그때 수정할 예정입니다.
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=3954-16261&mode=design&t=5EAvVlsch7kl27FP-4)
- 작동 영상:

	[asdf.webm](https://github.com/gnimty/frontend-gnimty/assets/72999818/fa861992-74a6-406a-9064-d2dbe1ad0a47)

