### PR TITLE
feat: add favorite button in summoner page

### DIFF
--- a/src/components/pages/main/search/SearchList.tsx
+++ b/src/components/pages/main/search/SearchList.tsx
@@ -1,17 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 
 import summonerAutoCompleteQuery, { type SummonerAutoCompleteResponse } from '@/apis/queries/summonerAutoCompleteQuery';
+import summonerDtoToSearchPopRowItem from '@/utils/summonerDtoToSearchPopRowItem';
 
 import SearchPopBody from './SearchPopBody';
 
 const summonerAutoCompleteToSearchPopRowItems = (data: SummonerAutoCompleteResponse) =>
-  data.data.summoners.map((summoner) => ({
-    puuid: summoner.puuid,
-    summonerName: summoner.summonerName,
-    tagLine: summoner.tagLine,
-    profileIconId: summoner.profileIconId,
-    isVerified: false,
-  }));
+  data.data.summoners.map(summonerDtoToSearchPopRowItem);
 
 interface SearchListProps {
   keyword: string;

--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -36,6 +36,7 @@ import StatusIndicator from '@/components/common/StatusIndicator';
 import TierImage from '@/components/common/TierImage';
 import FavoriteIcon from '@/components/icons/FavoriteIcon';
 import copyText from '@/utils/copyText';
+import summonerDtoToSearchPopRowItem from '@/utils/summonerDtoToSearchPopRowItem';
 
 import { useFavoriteSummonerMapStore } from '../../main/search/favoriteSummonerMapStore';
 import { useRecentSearchesStore } from '../../main/search/recentSearchesStore';
@@ -70,14 +71,7 @@ export default function Summoner(props: SummonerProps) {
     return;
   }
 
-  const searchPopRowItem = {
-    puuid: data.data.summoner.puuid,
-    summonerName: data.data.summoner.summonerName,
-    tagLine: data.data.summoner.tagLine,
-    profileIconId: data.data.summoner.profileIconId,
-    // TODO: 동적으로 설정
-    isVerified: false,
-  };
+  const searchPopRowItem = summonerDtoToSearchPopRowItem(data.data.summoner);
   const isFavorite = Object.hasOwn(favoriteSummonerMap, searchPopRowItem.puuid);
 
   if (!isRecentSearchAdded.current) {

--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -34,8 +34,10 @@ import Copy from '@/assets/icons/system/copy.svg';
 import Like from '@/assets/icons/system/like.svg';
 import StatusIndicator from '@/components/common/StatusIndicator';
 import TierImage from '@/components/common/TierImage';
+import FavoriteIcon from '@/components/icons/FavoriteIcon';
 import copyText from '@/utils/copyText';
 
+import { useFavoriteSummonerMapStore } from '../../main/search/favoriteSummonerMapStore';
 import { useRecentSearchesStore } from '../../main/search/recentSearchesStore';
 
 import Champion from './Champion';
@@ -61,20 +63,26 @@ export default function Summoner(props: SummonerProps) {
   const addRecentSearch = useRecentSearchesStore((state) => state.addRecentSearch);
   const isRecentSearchAdded = useRef(false);
 
+  const favoriteSummonerMap = useFavoriteSummonerMapStore((state) => state.favoriteSummonerMap);
+  const toggleFavoriteSummoner = useFavoriteSummonerMapStore((state) => state.toggleFavoriteSummoner);
+
   if (status !== 'success') {
     return;
   }
 
+  const searchPopRowItem = {
+    puuid: data.data.summoner.puuid,
+    summonerName: data.data.summoner.summonerName,
+    tagLine: data.data.summoner.tagLine,
+    profileIconId: data.data.summoner.profileIconId,
+    // TODO: 동적으로 설정
+    isVerified: false,
+  };
+  const isFavorite = Object.hasOwn(favoriteSummonerMap, searchPopRowItem.puuid);
+
   if (!isRecentSearchAdded.current) {
     isRecentSearchAdded.current = true;
-    addRecentSearch({
-      puuid: data.data.summoner.puuid,
-      summonerName: data.data.summoner.summonerName,
-      tagLine: data.data.summoner.tagLine,
-      profileIconId: data.data.summoner.profileIconId,
-      // TODO: 동적으로 설정
-      isVerified: false,
-    });
+    addRecentSearch(searchPopRowItem);
   }
 
   return (
@@ -153,12 +161,33 @@ export default function Summoner(props: SummonerProps) {
                     LP
                   </Text>
                 </HStack>
-                <HStack border="1px solid" borderColor="gray400" borderRadius="20px" p="4px 10px 4px 8px" gap="4px">
-                  <Like width={20} height={20} css={(theme) => ({ color: theme.colors.gray600 })} />
-                  <Text textStyle="t2" fontWeight="regular" color="gray700">
-                    {/* TODO: API에 관련 정보 추가해달라고 요청해야함 */}
-                    {Intl.NumberFormat().format(1234)}
-                  </Text>
+                <HStack>
+                  <Button
+                    type="button"
+                    onClick={() => {
+                      toggleFavoriteSummoner(searchPopRowItem);
+                    }}
+                    display="flex"
+                    borderWidth="1px"
+                    borderColor="gray400"
+                    borderStyle={isFavorite ? 'none' : 'solid'}
+                    borderRadius="20px"
+                    p="4px 10px 4px 8px"
+                    gap="4px"
+                    bg={isFavorite ? 'main' : 'transparent'}
+                  >
+                    <FavoriteIcon width={20} height={20} color={isFavorite ? '#fff' : '#4e4e4e'} isOn={isFavorite} />
+                    <Text textStyle="t2" fontWeight="regular" color={isFavorite ? 'white' : 'gray700'}>
+                      즐겨찾기
+                    </Text>
+                  </Button>
+                  <HStack border="1px solid" borderColor="gray400" borderRadius="20px" p="4px 10px 4px 8px" gap="4px">
+                    <Like width={20} height={20} css={(theme) => ({ color: theme.colors.gray600 })} />
+                    <Text textStyle="t2" fontWeight="regular" color="gray700">
+                      {/* TODO: API에 관련 정보 추가해달라고 요청해야함 */}
+                      {Intl.NumberFormat().format(1234)}
+                    </Text>
+                  </HStack>
                 </HStack>
               </VStack>
             </HStack>

--- a/src/utils/summonerDtoToSearchPopRowItem.ts
+++ b/src/utils/summonerDtoToSearchPopRowItem.ts
@@ -1,0 +1,13 @@
+import type { SummonerDto } from '@/apis/types';
+import type { SearchPopRowItem } from '@/components/pages/main/search/SearchPopRow';
+
+export default function summonerDtoToSearchPopRowItem(summoner: SummonerDto): SearchPopRowItem {
+  return {
+    puuid: summoner.puuid,
+    summonerName: summoner.summonerName,
+    tagLine: summoner.tagLine,
+    profileIconId: summoner.profileIconId,
+    // TODO: 동적으로 설정
+    isVerified: false,
+  };
+}


### PR DESCRIPTION
## Summary
소환사 페이지에 있는 소환사 카드에 즐겨찾기 버튼을 추가했습니다.

## Describe your changes
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=2235-10341&mode=design&t=5EAvVlsch7kl27FP-4)
- 작동 영상:

	[asdf.webm](https://github.com/gnimty/frontend-gnimty/assets/72999818/7124104b-6d3e-42b0-b4fb-108180a185c7)
