### PR TITLE
fix: group team correctly

### DIFF
--- a/src/apis/constants/teamId.ts
+++ b/src/apis/constants/teamId.ts
@@ -1,0 +1,4 @@
+import type { TEAM_ID } from '../types';
+
+export const BLUE_TEAM = 100 satisfies TEAM_ID;
+export const RED_TEAM = 200 satisfies TEAM_ID;

--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -312,8 +312,11 @@ export interface Perk {
   styles: PerkDetail[];
 }
 
+/** 100이 블루팀 200이 레드팀 */
+export type TEAM_ID = 100 | 200;
+
 export interface CurrentGameParticipantDto {
-  teamId: number;
+  teamId: TEAM_ID;
   summoner: SummonerDto;
   championId: number;
   championName: string;

--- a/src/components/pages/summoners/[summonerTagName]/CurrentGameTab/CurrentGameTab.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/CurrentGameTab/CurrentGameTab.tsx
@@ -35,7 +35,7 @@ export default function CurrentGameTab(props: CurrentGameTabProps) {
 
   const participantsByTeam = data.data.participants.reduce(
     (team, participant) => {
-      if (participant.teamId === 100) {
+      if (participant.teamId === 200) {
         team.red.push(participant);
       } else {
         team.blue.push(participant);

--- a/src/components/pages/summoners/[summonerTagName]/CurrentGameTab/CurrentGameTab.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/CurrentGameTab/CurrentGameTab.tsx
@@ -2,9 +2,9 @@ import { Box, HStack, Text } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 
-import { RED_TEAM } from '@/apis/constants/teamId';
+import { BLUE_TEAM, RED_TEAM } from '@/apis/constants/teamId';
 import summonerCurrentGameInfoQuery from '@/apis/queries/summonerCurrentGameInfoQuery';
-import type { CurrentGameParticipantDto } from '@/apis/types';
+import type { CurrentGameParticipantDto, TEAM_ID } from '@/apis/types';
 import useStopWatch from '@/hooks/useStopwatch';
 
 import CurrentGameRow from './CurrentGameRow';
@@ -36,14 +36,10 @@ export default function CurrentGameTab(props: CurrentGameTabProps) {
 
   const participantsByTeam = data.data.participants.reduce(
     (team, participant) => {
-      if (participant.teamId === RED_TEAM) {
-        team.red.push(participant);
-      } else {
-        team.blue.push(participant);
-      }
+      team[participant.teamId].push(participant);
       return team;
     },
-    { red: [] as CurrentGameParticipantDto[], blue: [] as CurrentGameParticipantDto[] },
+    { [BLUE_TEAM]: [], [RED_TEAM]: [] } as Record<TEAM_ID, CurrentGameParticipantDto[]>,
   );
 
   return (
@@ -58,8 +54,8 @@ export default function CurrentGameTab(props: CurrentGameTabProps) {
         </HStack>
       </HStack>
       <HStack bg="linear-gradient(270deg, #FDE7EA 44.32%, #EBF3FE 55.1%)" gap={0}>
-        <CurrentGameRow team="blue" participants={participantsByTeam.blue} />
-        <CurrentGameRow team="red" participants={participantsByTeam.red} />
+        <CurrentGameRow team="blue" participants={participantsByTeam[BLUE_TEAM]} />
+        <CurrentGameRow team="red" participants={participantsByTeam[RED_TEAM]} />
       </HStack>
     </Box>
   );

--- a/src/components/pages/summoners/[summonerTagName]/CurrentGameTab/CurrentGameTab.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/CurrentGameTab/CurrentGameTab.tsx
@@ -2,6 +2,7 @@ import { Box, HStack, Text } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 
+import { RED_TEAM } from '@/apis/constants/teamId';
 import summonerCurrentGameInfoQuery from '@/apis/queries/summonerCurrentGameInfoQuery';
 import type { CurrentGameParticipantDto } from '@/apis/types';
 import useStopWatch from '@/hooks/useStopwatch';
@@ -35,7 +36,7 @@ export default function CurrentGameTab(props: CurrentGameTabProps) {
 
   const participantsByTeam = data.data.participants.reduce(
     (team, participant) => {
-      if (participant.teamId === 200) {
+      if (participant.teamId === RED_TEAM) {
         team.red.push(participant);
       } else {
         team.blue.push(participant);


### PR DESCRIPTION
## Summary
인게임 탭에서 레드팀과 블루팀이 반대로 표시되는 현상을 수정했습니다.

## Describe your changes
`teamId`가 헷갈리는 근본적인 현상을 해결하기 위해 리팩터링도 진행했습니다.
