### PR TITLE
fix: display properly when soloTierInfo is null

### DIFF
--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -146,14 +146,19 @@ export default function Summoner(props: SummonerProps) {
                   #{data.data.summoner.tagLine}
                 </Text>
                 <HStack gap="8px">
-                  <TierImage tier={data.data.summoner.soloTierInfo.tier} width={28} height={28} />
+                  <TierImage tier={data.data.summoner.soloTierInfo?.tier ?? 'unknown'} width={28} height={28} />
                   <Text textStyle="h3" color="gray800" fontWeight="bold">
-                    {fullTierName(data.data.summoner.soloTierInfo.tier, data.data.summoner.soloTierInfo.division)}
+                    {fullTierName(
+                      data.data.summoner.soloTierInfo?.tier ?? 'unknown',
+                      data.data.summoner.soloTierInfo?.division,
+                    )}
                   </Text>
-                  <Text textStyle="h3" fontWeight="regular" color="gray500">
-                    {Intl.NumberFormat().format(data.data.summoner.soloTierInfo.lp)}
-                    LP
-                  </Text>
+                  {data.data.summoner.soloTierInfo !== null && (
+                    <Text textStyle="h3" fontWeight="regular" color="gray500">
+                      {Intl.NumberFormat().format(data.data.summoner.soloTierInfo.lp)}
+                      LP
+                    </Text>
+                  )}
                 </HStack>
                 <HStack>
                   <Button


### PR DESCRIPTION
## Summary
소환사 상세 페이지에서 `soloTierInfo`가  `null`로 올 때 크래시를 막고 정상적으로 표시되게 수정했습니다.

## Describe your changes
- 렌더링 된 모습:
	- 수정 전:
		![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/c2c7b6db-1a3b-4533-a79a-b797d2cc6e40)
	- 수정 후:
		![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/18b6f5f4-1e8f-4a18-9643-62785afd3ee5)
