### PR TITLE
fix: display properly when avgKda is null

### DIFF
--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -251,7 +251,7 @@ export default function Summoner(props: SummonerProps) {
                             {Math.floor(champion.winRate * 100)}%
                           </Text>
                           <Text w="60px" textStyle="body" color="orange800" fontWeight="bold">
-                            {champion.avgKda.toFixed(2)} 평점
+                            {champion.isPerfect ? 'Perfect' : `${champion.avgKda.toFixed(2)} 평점`}
                           </Text>
                         </VStack>
                       </HStack>

--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -238,7 +238,7 @@ export default function Summoner(props: SummonerProps) {
                   </HStack>
                   <HStack gap="20px">
                     {data.data.matchSummary.championSummary.map((champion) => (
-                      <HStack key={champion.avgKda} gap="12px" alignItems="normal">
+                      <HStack key={champion.championId} gap="12px" alignItems="normal">
                         <Image
                           src={championIconUrl(championIdEnNameMap[champion.championId])}
                           width={36}


### PR DESCRIPTION
## Summary
소환사 페이지에서 챔피언의 `avgKda`가 `null`일 때 크래시 나는 문제를 해결했습니다. 추가로 `key`에 중복될 수 있는 값이 사용되는 걸 발견해서 수정했습니다.

## Describe your changes
- 수정 전:
	![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/8306f629-a150-4680-aa63-53dc3ab2a316)
- 수정 후:
	![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/66e24540-c927-450a-b211-b055642f89f0)
