### PR TITLE
fix: duo page filter, detail filter

### DIFF
--- a/src/components/duo/Champion.tsx
+++ b/src/components/duo/Champion.tsx
@@ -66,23 +66,24 @@ const SelectedChecker = styled.div<{ selected: boolean }>`
 `;
 
 interface ChampionProps {
-  championName: string; // championEnName
+  championKrName: string; // championKrName
+  championEnName: string; // championEnName
   selected?: boolean;
   onClick: (championName: string) => void;
 }
 
-const Champion = ({ championName, selected = false, onClick }: ChampionProps) => {
+const Champion = ({ championKrName, championEnName, selected = false, onClick }: ChampionProps) => {
   return (
-    <Container onClick={() => onClick(championName)}>
+    <Container onClick={() => onClick(championEnName)}>
       <ChampionImageWrapper selected={selected}>
         {selected && (
           <SelectedChecker selected={selected}>
             <CheckIcon fill="#fff" width="70%" />
           </SelectedChecker>
         )}
-        <Image src={championIconUrl(championName)} alt={championName} width={40} height={40} />
+        <Image src={championIconUrl(championEnName)} alt={championEnName} width={40} height={40} />
       </ChampionImageWrapper>
-      <ChampionName>{championName}</ChampionName>
+      <ChampionName>{championKrName}</ChampionName>
     </Container>
   );
 };

--- a/src/components/duo/DetailDrawer.tsx
+++ b/src/components/duo/DetailDrawer.tsx
@@ -80,6 +80,8 @@ const DetailDrawer = ({ disclosure, updateParams }: DetailDrawerProps) => {
     e.preventDefault();
     const formData = Object.fromEntries(new FormData(e.currentTarget)) as Partial<DuoSummonersRequest>;
     updateParams(formData);
+    // reset champions
+    setFilteredChampions([]);
     disclosure.onClose();
   };
 

--- a/src/components/duo/DetailDrawer.tsx
+++ b/src/components/duo/DetailDrawer.tsx
@@ -51,7 +51,9 @@ const DetailDrawer = ({ disclosure, updateParams }: DetailDrawerProps) => {
     if (!value) {
       return setFilteredChampions([]);
     }
-    const searchedChampions = champions.filter((championInfo) => championInfo.krName.includes(value));
+    const searchedChampions = champions.filter(
+      (championInfo) => championInfo.krName.includes(value) || championInfo.enName.includes(value),
+    );
     setFilteredChampions(searchedChampions.map((championInfo) => ({ ...championInfo, selected: false })));
   };
 
@@ -61,7 +63,7 @@ const DetailDrawer = ({ disclosure, updateParams }: DetailDrawerProps) => {
         return prev;
       }
       return prev.map((championInfo) => {
-        if (championInfo.krName === championName) {
+        if (championInfo.enName === championName) {
           return { ...championInfo, selected: !championInfo.selected };
         }
         return championInfo;
@@ -144,8 +146,13 @@ const DetailDrawer = ({ disclosure, updateParams }: DetailDrawerProps) => {
                     <Grid templateColumns="repeat(8, 1fr)" gap="8px" h="max-content" minH="60px">
                       {filteredChampions
                         .filter(({ selected }) => !selected)
-                        .map(({ enName }) => (
-                          <Champion key={enName} championName={enName} onClick={handleChampionClick} />
+                        .map(({ krName, enName }) => (
+                          <Champion
+                            key={enName}
+                            championKrName={krName}
+                            championEnName={enName}
+                            onClick={handleChampionClick}
+                          />
                         ))}
                     </Grid>
                   )}
@@ -153,10 +160,11 @@ const DetailDrawer = ({ disclosure, updateParams }: DetailDrawerProps) => {
                     <Grid templateColumns="repeat(8, 1fr)" gap="8px">
                       {filteredChampions
                         .filter(({ selected }) => selected)
-                        .map(({ enName, selected }) => (
+                        .map(({ krName, enName, selected }) => (
                           <Champion
                             key={enName}
-                            championName={enName}
+                            championKrName={krName}
+                            championEnName={enName}
                             onClick={handleChampionClick}
                             selected={selected}
                           />

--- a/src/components/duo/Filter.tsx
+++ b/src/components/duo/Filter.tsx
@@ -143,12 +143,7 @@ const Filter = ({ disclosure, allOpen, toggleAll, requestParams, updateParams }:
   };
 
   useEffect(() => {
-    if (requestParams.lanes === undefined) {
-      updateParams({ lanes: selected });
-    }
-    if (Array.isArray(requestParams.lanes) && !isEqualArray(requestParams.lanes, selected)) {
-      updateParams({ lanes: selected });
-    }
+    updateParams({ lanes: selected.join(',') });
   }, [selected, updateParams, requestParams.lanes]);
 
   return (
@@ -212,20 +207,20 @@ const Filter = ({ disclosure, allOpen, toggleAll, requestParams, updateParams }:
           <FilterIconItem data-position="ALL" selected={selected.length === 0}>
             <Unselected fill={selected.length === 0 ? theme.colors.white : undefined} />
           </FilterIconItem>
-          <FilterIconItem data-position="top" selected={selected.includes('top')}>
-            <PositionImage position="TOP" fill={selected.includes('top') ? theme.colors.white : undefined} />
+          <FilterIconItem data-position="TOP" selected={selected.includes('TOP')}>
+            <PositionImage position="TOP" fill={selected.includes('TOP') ? theme.colors.white : undefined} />
           </FilterIconItem>
-          <FilterIconItem data-position="jug" selected={selected.includes('jug')}>
-            <PositionImage position="JUNGLE" fill={selected.includes('jug') ? theme.colors.white : undefined} />
+          <FilterIconItem data-position="JUNGLE" selected={selected.includes('JUNGLE')}>
+            <PositionImage position="JUNGLE" fill={selected.includes('JUNGLE') ? theme.colors.white : undefined} />
           </FilterIconItem>
-          <FilterIconItem data-position="mid" selected={selected.includes('mid')}>
-            <PositionImage position="MIDDLE" fill={selected.includes('mid') ? theme.colors.white : undefined} />
+          <FilterIconItem data-position="MIDDLE" selected={selected.includes('MIDDLE')}>
+            <PositionImage position="MIDDLE" fill={selected.includes('MIDDLE') ? theme.colors.white : undefined} />
           </FilterIconItem>
-          <FilterIconItem data-position="bot" selected={selected.includes('bot')}>
-            <PositionImage position="BOTTOM" fill={selected.includes('bot') ? theme.colors.white : undefined} />
+          <FilterIconItem data-position="BOTTOM" selected={selected.includes('BOTTOM')}>
+            <PositionImage position="BOTTOM" fill={selected.includes('BOTTOM') ? theme.colors.white : undefined} />
           </FilterIconItem>
-          <FilterIconItem data-position="sup" selected={selected.includes('sup')}>
-            <PositionImage position="UTILITY" fill={selected.includes('sup') ? theme.colors.white : undefined} />
+          <FilterIconItem data-position="UTILITY" selected={selected.includes('UTILITY')}>
+            <PositionImage position="UTILITY" fill={selected.includes('UTILITY') ? theme.colors.white : undefined} />
           </FilterIconItem>
         </FilterIconBox>
 

--- a/src/pages/duo.tsx
+++ b/src/pages/duo.tsx
@@ -19,6 +19,7 @@ export const defaultDuoSummonersRequest: DuoSummonersRequest = {
   status: 'ONLINE',
   sortBy: 'RECOMMEND',
   tier: 'unknown',
+  lanes: [],
   lastSummonerId: null,
   lastName: null,
   lastSummonerUpCount: null,


### PR DESCRIPTION
## Summary

- 듀오 페이지에서 lanes 검색 시 lanes[]: string 형태로 보내지는 오류가 있었습니다
- Champion 컴포넌트가 영문 챔피언 이름을 표기하는 문제가 있었습니다

## Describe your changes

- 듀오 페이지 lanes 선택 시 join으로 수정
- 챔피언 검색 한/영 가능하게 설정
- 챔피언 컴포넌트 챔피언 이름 한글로 수정
- 챔피언 선택 후 저장 시 리셋되도록 수정
