### PR TITLE
fix: effect dependency change - blocking problem

### DIFF
--- a/src/components/duo/Filter.tsx
+++ b/src/components/duo/Filter.tsx
@@ -144,7 +144,7 @@ const Filter = ({ disclosure, allOpen, toggleAll, requestParams, updateParams }:
 
   useEffect(() => {
     updateParams({ lanes: selected.join(',') });
-  }, [selected, updateParams, requestParams.lanes]);
+  }, [selected]);
 
   return (
     <HStack w="full" justify="space-between">

--- a/src/components/duo/Filter.tsx
+++ b/src/components/duo/Filter.tsx
@@ -15,7 +15,6 @@ import StatusIndicator from '@/components/common/StatusIndicator';
 import TierImage from '@/components/common/TierImage';
 import ToggleSwitch from '@/components/common/ToggleSwitch';
 import { defaultDuoSummonersRequest } from '@/pages/duo';
-import { isEqualArray } from '@/utils/array';
 
 import type { UseDisclosureReturn } from '@chakra-ui/react';
 
@@ -144,7 +143,7 @@ const Filter = ({ disclosure, allOpen, toggleAll, requestParams, updateParams }:
 
   useEffect(() => {
     updateParams({ lanes: selected.join(',') });
-  }, [selected]);
+  }, [selected, updateParams]);
 
   return (
     <HStack w="full" justify="space-between">

--- a/src/pages/duo.tsx
+++ b/src/pages/duo.tsx
@@ -50,9 +50,12 @@ export default function Duo() {
     },
     [fetchNextPage, hasNextPage],
   );
-  const updateRequestParams = (toUpdate: Record<string, DuoSummonersRequest[keyof DuoSummonersRequest]>) => {
-    setRequestParams((prev) => ({ ...prev, ...toUpdate }));
-  };
+  const updateRequestParams = useCallback(
+    (toUpdate: Record<string, DuoSummonersRequest[keyof DuoSummonersRequest]>) => {
+      setRequestParams((prev) => ({ ...prev, ...toUpdate }));
+    },
+    [],
+  );
 
   const [summoners, setSummoners] = useState<SummonerCardItem[]>([]);
   const [allOpen, setAllOpen] = useState(false);


### PR DESCRIPTION
## Summary

- duo/Filter 컴포넌트에 의한 무한루프 생성이 있어 변경하였습니다

## Describe your changes

- 해당 무한루프로 인해 duo에서 다른 페이지로 url은 변하나 컴포넌트 라우팅이 바뀌지 않는 문제가 있었습니다
- 기존에 lanes가 null인 경우를 대비하여 비교로직을 넣었으나 빼면서 함께 제거하지 않았던 의존성 requestParams.lanes를 제거했고, updateParams는 전달 이후 재참조할 필요 없어서 제거했습니다

