### PR TITLE
fix: no-rank-user-chat

### DIFF
--- a/src/apis/queries/summonerInfoQuery.ts
+++ b/src/apis/queries/summonerInfoQuery.ts
@@ -1,8 +1,10 @@
 import { queryOptions } from '@tanstack/react-query';
 
+
 import httpRequest from '../httpRequest';
 
 import type { SummonerDto } from '../types';
+import type { AxiosError } from 'axios';
 
 interface Options {
   summonerTagName: string;
@@ -22,6 +24,11 @@ const summonerInfoQuery = ({ summonerTagName }: Options) =>
       return res.data;
     },
     enabled: !!summonerTagName,
+    retry(failureCount, error: AxiosError) {
+      if (error.response?.status === 404) return false;
+      if (failureCount < 3) return true;
+      return false;
+    },
   });
 
 export default summonerInfoQuery;

--- a/src/apis/queries/summonerInfoQuery.ts
+++ b/src/apis/queries/summonerInfoQuery.ts
@@ -1,6 +1,5 @@
 import { queryOptions } from '@tanstack/react-query';
 
-
 import httpRequest from '../httpRequest';
 
 import type { SummonerDto } from '../types';

--- a/src/components/chat/CurrentChat.tsx
+++ b/src/components/chat/CurrentChat.tsx
@@ -40,8 +40,8 @@ function CurrentChat() {
         summonerName="TestUserName"
         tagLine="#KR1"
         profileIconId={100}
-        soloTierInfo={summonerInfo?.data.summoner.soloTierInfo}
-        flexTierInfo={summonerInfo?.data.summoner.flexTierInfo}
+        soloTierInfo={summonerInfo?.data.summoner?.soloTierInfo}
+        flexTierInfo={summonerInfo?.data.summoner?.flexTierInfo}
       />
       {/* if chat exists */}
       <Box overflowY="scroll" w="full" flex="1" mb="70px" ref={scrollRef}>

--- a/src/components/chat/UserCard.tsx
+++ b/src/components/chat/UserCard.tsx
@@ -44,14 +44,15 @@ function UserCard({ summonerName, tagLine, profileIconId, soloTierInfo, flexTier
             <CopyIcon width="16" color="gray500" onClick={() => console.log('Copied!')} />
           </HStack>
         </HStack>
-        {!isOpen && (
+        {/* 랭크전적 있을때만 펼치기 가능하도록 */}
+        {soloTierInfo && !isOpen && (
           <Box textStyle="body" color="gray500" onClick={onOpen}>
             펼쳐두기
           </Box>
         )}
       </HStack>
       {/* 유저 정보 디테일 */}
-      {isOpen && (
+      {soloTierInfo && isOpen && (
         <HStack w="full" spacing="24px" justifyContent="space-between">
           {soloTierInfo && <RankInfo type="solo" rankInfo={soloTierInfo} />}
           {flexTierInfo && <RankInfo type="flex" rankInfo={flexTierInfo} />}


### PR DESCRIPTION
## Summary

- 채팅 상대방 전적 정보가 없을 시의 오류 수정

## Describe your changes

- 상대 전적 정보 없을 시 RankInfo 렌더링 X
- 전적 정보 쿼리 404 시 retry 방지

- #147의 브랜치에서 추가 브랜치를 생성했습니다