### PR TITLE
feat: add loading state for renew button

### DIFF
--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -20,6 +20,7 @@ import duration from 'dayjs/plugin/duration';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import Head from 'next/head';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import { useRef } from 'react';
 
 import championIdEnNameMap from '@/apis/constants/championIdEnNameMap';
@@ -59,13 +60,15 @@ export default function Summoner(props: SummonerProps) {
 
   const { data, status } = useQuery(summonerMatchesInfoQuery({ summonerTagName }));
 
-  const { renewSummoner } = useRenewSummoner();
+  const { renewSummoner, status: renewSummonerStatus } = useRenewSummoner();
 
   const addRecentSearch = useRecentSearchesStore((state) => state.addRecentSearch);
   const isRecentSearchAdded = useRef(false);
 
   const favoriteSummonerMap = useFavoriteSummonerMapStore((state) => state.favoriteSummonerMap);
   const toggleFavoriteSummoner = useFavoriteSummonerMapStore((state) => state.toggleFavoriteSummoner);
+
+  const router = useRouter();
 
   if (status !== 'success') {
     return;
@@ -206,12 +209,27 @@ export default function Summoner(props: SummonerProps) {
                   bg="black"
                   color="white"
                   flex="1 1 0"
+                  isDisabled={renewSummonerStatus === 'pending'}
+                  _disabled={{
+                    cursor: 'wait',
+                    bg: 'gray200',
+                    color: 'gray500',
+                  }}
                   onClick={() => {
-                    // TODO: 로딩 처리와 성공 혹은 에러 시 유저에게 피드백 필요
-                    renewSummoner({ puuid: data.data.summoner.puuid });
+                    // TODO: 에러에 대한 처리 필요
+                    renewSummoner(
+                      { puuid: data.data.summoner.puuid },
+                      {
+                        onSuccess() {
+                          alert('성공적으로 소환사 정보가 갱신됐습니다!');
+                          // TODO: 페이지 새로고침 대신 `invalidateQueries()`를 사용해 데이터 갱신
+                          router.reload();
+                        },
+                      },
+                    );
                   }}
                 >
-                  전적 갱신
+                  {renewSummonerStatus === 'pending' ? '갱신중' : '전적 갱신'}
                 </Button>
                 <Button size="lg" variant="default" flex="1 1 0" display="inline-flex" gap="4px">
                   <Chat width={24} height={24} aria-hidden /> 채팅하기


### PR DESCRIPTION
## Summary
소환사 상세 페이지에 전적 갱신 버튼을 누를시 로딩 중 표시가 뜨게하고 완료됐을 시 `alert()`를 통해 사용자에게 알린 후 페이지를 새로고침합니다.

## Describe your changes
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=3720-13916&mode=design&t=xn2vnk6ronC2o82O-4)
- 작동 영상:

	[asdf.webm](https://github.com/gnimty/frontend-gnimty/assets/72999818/204c8671-a4cb-43bc-9fd0-ee60288bbb55)

	