### PR TITLE
feat: add wins and defeats in summoner page

### DIFF
--- a/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
+++ b/src/components/pages/summoners/[summonerTagName]/Summoner.tsx
@@ -89,7 +89,16 @@ export default function Summoner(props: SummonerProps) {
       </Head>
       <VStack gap="40px" w="1080px" m="40px auto 60px">
         <HStack gap="12px" w="full">
-          <VStack alignItems="normal" w="447px" h="264px" bg="white" p="20px" gap="12px">
+          <VStack
+            gap={0}
+            alignItems="normal"
+            alignSelf="stretch"
+            w="447px"
+            bg="white"
+            p="20px"
+            justify="space-between"
+            borderRadius="4px"
+          >
             <HStack alignItems="normal" gap="24px">
               <Box pos="relative" width="100px" height="100px">
                 <Image
@@ -238,11 +247,11 @@ export default function Summoner(props: SummonerProps) {
             </VStack>
           </VStack>
           <VStack gap="12px" flex="1">
-            <HStack gap="12px" h="112px" w="full">
+            <HStack gap="12px" w="full">
               <RankCard tierType="solo" tierInfo={data.data.summoner.soloTierInfo} />
               <RankCard tierType="flex" tierInfo={data.data.summoner.flexTierInfo} />
             </HStack>
-            <VStack alignItems="normal" gap="12px" bg="white" h="140px" w="full" p="20px" borderRadius="4px">
+            <VStack alignItems="normal" gap="12px" bg="white" w="full" p="20px" borderRadius="4px">
               <Text textStyle="t2" fontWeight="regular" color="gray700">
                 최근 게임 결과
               </Text>
@@ -272,6 +281,9 @@ export default function Summoner(props: SummonerProps) {
                         <VStack alignItems="normal" gap={0}>
                           <Text w="48px" textStyle="t2" color="gray800" fontWeight="bold">
                             {Math.floor(champion.winRate * 100)}%
+                          </Text>
+                          <Text textStyle="caption" fontWeight="normal" color="gray800">
+                            {champion.wins}승 {champion.defeats}패
                           </Text>
                           <Text w="60px" textStyle="body" color="orange800" fontWeight="bold">
                             {champion.isPerfect ? 'Perfect' : `${champion.avgKda.toFixed(2)} 평점`}


### PR DESCRIPTION
## Summary
소환사 페이지 최근 게임 결과에 챔피언별 승/패 수를 추가 했습니다.

## Describe your changes
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=2236-33413&mode=design&t=i0hjKiEkiKq1IjZH-4)
- 변경 전 모습:
	![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/950e9e60-a5bf-4d34-8224-9bb4ddf3d920)
- 변경 후 모습:
	![image](https://github.com/gnimty/frontend-gnimty/assets/72999818/578752d3-af55-404a-9029-6df52e677324)
