### PR TITLE
feat: champion icon component

### DIFF
--- a/src/components/common/ChampionIcon.tsx
+++ b/src/components/common/ChampionIcon.tsx
@@ -1,0 +1,36 @@
+import { Box } from '@chakra-ui/react';
+import Image from 'next/image';
+
+import championIconUrl from '@/apis/utils/championIconUrl';
+
+interface ChampionIconProps {
+  championEnName: string;
+  width: number;
+  height: number;
+  radius?: number;
+}
+
+export default function ChampionIcon({ championEnName, width, height, radius }: ChampionIconProps) {
+  const capitalizedChampionEnName = championEnName.charAt(0).toUpperCase() + championEnName.slice(1);
+  return (
+    <Box
+      w={`${width}px`}
+      h={`${height}px`}
+      borderRadius={radius}
+      overflow="hidden"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Image
+        src={championIconUrl(capitalizedChampionEnName)}
+        alt={championEnName}
+        width={width}
+        height={height}
+        css={{
+          transform: 'scale(1.2)',
+        }}
+      />
+    </Box>
+  );
+}

--- a/src/components/pages/information/RotationChampions.tsx
+++ b/src/components/pages/information/RotationChampions.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 
 import rotationChampionsQuery from '@/apis/queries/rotationChampionsQuery';
 import championIconUrl from '@/apis/utils/championIconUrl';
+import ChampionIcon from '@/components/common/ChampionIcon';
 
 export default function RotationChampions() {
   const { data, status } = useQuery(rotationChampionsQuery());
@@ -20,7 +21,7 @@ export default function RotationChampions() {
       <HStack as="ul" gap="16px" w="1040px" flexWrap="wrap" justifyContent="center">
         {data.data.champions.map((champ) => (
           <VStack key={champ.championId} as="li" gap="4px">
-            <Image src={championIconUrl(champ.enName)} alt="" width={80} height={80} css={{ borderRadius: '9999px' }} />
+            <ChampionIcon championEnName={champ.enName} width={80} height={80} radius={40} />
             <Box
               w="80px"
               textStyle="t2"

--- a/src/components/pages/information/RotationChampions.tsx
+++ b/src/components/pages/information/RotationChampions.tsx
@@ -1,9 +1,7 @@
 import { Box, HStack, Heading, VStack } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
-import Image from 'next/image';
 
 import rotationChampionsQuery from '@/apis/queries/rotationChampionsQuery';
-import championIconUrl from '@/apis/utils/championIconUrl';
 import ChampionIcon from '@/components/common/ChampionIcon';
 
 export default function RotationChampions() {


### PR DESCRIPTION
## Summary

- 챔피언 이미지의 검은 박스 구역을 안보이게 하기 위한 제작입니다
- champion icon 컴포넌트를 생성했습니다
- 할인/패치노트 페이지에 시험 적용했습니다

## Describe your changes

-

[before]
![image](https://github.com/gnimty/frontend-gnimty/assets/75024621/e2995500-b00a-4b96-b7cc-1b759da6929b)

[after]
![image](https://github.com/gnimty/frontend-gnimty/assets/75024621/1e19fbc5-f25d-479f-890c-33d78caa6f98)

