### PR TITLE
feat: improve search

### DIFF
--- a/src/components/common/SummonerSearchBar.tsx
+++ b/src/components/common/SummonerSearchBar.tsx
@@ -4,15 +4,22 @@ import { useState, type FormEventHandler } from 'react';
 
 import SearchIcon from '@/assets/icons/system/search.svg';
 
-import FavoriteSummonersTab from './FavoriteSummonersTab';
-import RecentSearchTab from './RecentSearchesTab';
-import SearchList from './SearchList';
+import FavoriteSummonersTab from '../pages/main/search/FavoriteSummonersTab';
+import RecentSearchTab from '../pages/main/search/RecentSearchesTab';
+import SearchList from '../pages/main/search/SearchList';
 
 import type { BoxProps } from '@chakra-ui/react';
 
-export interface SearchProps extends Omit<BoxProps, 'children'> {}
+export interface SummonerSearchBarProps extends Omit<BoxProps, 'children'> {
+  /**
+   * @defaultValue `'in-home'`
+   */
+  size?: 'in-home' | 'in-header';
+}
 
-export default function Search(props: SearchProps) {
+export default function SummonerSearchBar(props: SummonerSearchBarProps) {
+  const { size = 'in-home', ...restProps } = props;
+
   const [searchKeyword, setSearchKeyword] = useState('');
   const [searchPopState, setSearchPopState] = useState<'hidden' | 'recent-favorite' | 'search'>('hidden');
 
@@ -34,15 +41,15 @@ export default function Search(props: SearchProps) {
     >
       <HStack
         gap="12px"
-        p="12px 24px"
-        w="420px"
+        p={size === 'in-home' ? '12px 24px' : '8px 20px'}
+        w={size === 'in-home' ? '420px' : '280px'}
         bg="white"
         borderRadius="40px"
         boxShadow="0 0 0 1px"
         color="gray200"
-        {...props}
+        {...restProps}
       >
-        <Box w="38px" h="20px">
+        <Box w={size === 'in-home' ? '38px' : undefined}>
           <Text textStyle="t2" fontWeight="regular" color="gray800">
             KR
           </Text>

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -63,9 +63,11 @@ export default function Header() {
 
         {isAuthenticated ? (
           <Flex position="relative" gap="8px">
-            <Flex w="40px" h="40px" justifyContent="center" alignContent="center">
-              <IconButton w="28px" aria-label="search" icon={<IconSearch />} />
-            </Flex>
+            {router.pathname !== '/' && (
+              <Flex w="40px" h="40px" justifyContent="center" alignContent="center">
+                <IconButton w="28px" aria-label="search" icon={<IconSearch />} />
+              </Flex>
+            )}
             <Flex w="40px" h="40px" justifyContent="center" alignContent="center">
               <IconButton w="28px" aria-label="search" icon={<IconLike />} />
             </Flex>

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -7,12 +7,12 @@ import { useEffect } from 'react';
 import useGetMyInfo from '@/apis/useGetMyInfo';
 import { logout } from '@/apis/useLogout';
 import IconLike from '@/assets/icons/system/like.svg';
-import IconSearch from '@/assets/icons/system/search.svg';
 import Select from '@/components/common/select/Select';
 import AccountModal from '@/components/pages/account/AccountModal';
 import { useAuthContext } from '@/contexts/AuthContext';
 
 import ActiveLink from '../common/ActiveLink';
+import SummonerSearchBar from '../common/SummonerSearchBar';
 
 import * as style from './Header.style';
 
@@ -63,11 +63,7 @@ export default function Header() {
 
         {isAuthenticated ? (
           <Flex position="relative" gap="8px">
-            {router.pathname !== '/' && (
-              <Flex w="40px" h="40px" justifyContent="center" alignContent="center">
-                <IconButton w="28px" aria-label="search" icon={<IconSearch />} />
-              </Flex>
-            )}
+            {router.pathname !== '/' && <SummonerSearchBar size="in-header" />}
             <Flex w="40px" h="40px" justifyContent="center" alignContent="center">
               <IconButton w="28px" aria-label="search" icon={<IconLike />} />
             </Flex>

--- a/src/components/pages/main/Main.tsx
+++ b/src/components/pages/main/Main.tsx
@@ -6,10 +6,11 @@ import Logo from '@/assets/images/logo.svg';
 import Select from '@/components/common/select/Select';
 import type { SelectOption } from '@/components/common/select/useSelect';
 
+import SummonerSearchBar from '../../common/SummonerSearchBar';
+
 import ChampionsTable from './ChampionsTable';
 import RecentMatches from './RecentMatches';
 import RecommendedSummonersSection from './RecommendedSummonersSection';
-import Search from './search/Search';
 
 const queueSelectOptions: SelectOption<GameMode>[] = [
   {
@@ -39,7 +40,7 @@ export default function Main() {
         <Flex color="main">
           <Logo width={170} height={80} aria-label="그님티" />
         </Flex>
-        <Search />
+        <SummonerSearchBar />
       </VStack>
       <HStack mb="16px" justifyContent="space-between" gap={0}>
         <Select options={queueSelectOptions} onChange={handleGameModeChanged} css={{ width: '124px' }} />

--- a/src/components/pages/main/search/Search.tsx
+++ b/src/components/pages/main/search/Search.tsx
@@ -38,8 +38,8 @@ export default function Search(props: SearchProps) {
         w="420px"
         bg="white"
         borderRadius="40px"
-        border="1px solid"
-        borderColor="gray200"
+        boxShadow="0 0 0 1px"
+        color="gray200"
         {...props}
       >
         <Box w="38px" h="20px">
@@ -72,7 +72,7 @@ export default function Search(props: SearchProps) {
             p={0}
             css={{ '::-webkit-search-cancel-button': { display: 'none' } }}
           />
-          <IconButton type="submit" aria-label="검색" display="inline-flex">
+          <IconButton type="submit" aria-label="검색" display="inline-flex" color="gray800">
             <SearchIcon width={24} height={24} />
           </IconButton>
         </HStack>


### PR DESCRIPTION
## Summary
소환사 검색창 관련한 PR입니다.

## Describe your changes
- 메인 페이지에서 메인 페이지의 검색바와 헤더의 검색바가 중복 되어서 메인 페이지에서는 헤더의 검색바가 보이지 않게 수정했습니다.
- 헤더에 검색 아이콘 대신 검색창이 그대로 보이게 했습니다.
- [관련 피그마 댓글](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe?type=design&node-id=3531-38416&mode=design#737900841), [디자인 피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=4349-15217&mode=design&t=nArLfekrTkTUjfov-4)
- 작동 영상:

	https://github.com/gnimty/frontend-gnimty/assets/72999818/52e8eab5-d31d-4e1c-b263-88a25be4f57e
