### PR TITLE
feat: champions summary tab per position

### DIFF
--- a/src/apis/queries/championsTierQuery.ts
+++ b/src/apis/queries/championsTierQuery.ts
@@ -27,7 +27,7 @@ interface Options {
   queue_type?: Extract<GameMode, 'RANK_SOLO' | 'RANK_FLEX'>;
 }
 
-const championsTierQuery = (options: Options) =>
+const championsTierQuery = (options: Options = {}) =>
   queryOptions({
     queryKey: ['rankTiers', options],
     async queryFn() {

--- a/src/components/pages/champions/ChampionsSummaryTabs.tsx
+++ b/src/components/pages/champions/ChampionsSummaryTabs.tsx
@@ -1,16 +1,72 @@
 import { Link } from '@chakra-ui/next-js';
 import { Grid, GridItem, Tab, TabList, TabPanel, TabPanels, Tabs, Text } from '@chakra-ui/react';
+import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useState } from 'react';
 
 import championIdEnNameMap from '@/apis/constants/championIdEnNameMap';
 import championIdKrNameMap from '@/apis/constants/championIdKrNameMap';
+import championsTierQuery from '@/apis/queries/championsTierQuery';
+import type { ChampionTierDto } from '@/apis/types';
 import championIconUrl from '@/apis/utils/championIconUrl';
 import PositionImage from '@/components/common/position-image/PositionImage';
 import Unselected from '@/components/common/position-image/Unselected';
 
+function ChampionsSummaryTab(props: { champions: ChampionTierDto[] }) {
+  const { champions } = props;
+
+  return (
+    <Grid as="ul" gap="8px" templateColumns="repeat(6, 1fr)" justifyItems="center">
+      {champions
+        /**
+         * TODO: `??` 연산자는 현재 챔피언 한글 이름이 지정되어 있지 않은 챔피언 때문에 임시로 사용함.
+         * 후에 챔피언 관련 정보를 동적으로 받아올 수 있게 코드가 리팩터링 된 후에 필요없는 `??` 연산자 삭제.
+         */
+        .sort((a, b) => (championIdKrNameMap[a.championId] ?? '').localeCompare(championIdKrNameMap[b.championId]))
+        .map((champion) => (
+          <GridItem as="li" key={champion.championId}>
+            <Link
+              href={`/champions/${champion.championName}`}
+              display="flex"
+              flexDir="column"
+              gap="4px"
+              textDecor="none"
+            >
+              <Image
+                src={championIconUrl(champion.championName)}
+                alt={championIdKrNameMap[champion.championId]}
+                width={40}
+                height={40}
+                css={{
+                  borderRadius: '999px',
+                }}
+              />
+              <Text
+                w="40px"
+                textStyle="body"
+                fontWeight="regular"
+                color="gray700"
+                textOverflow="ellipsis"
+                overflow="hidden"
+                whiteSpace="nowrap"
+              >
+                {championIdKrNameMap[champion.championId]}
+              </Text>
+            </Link>
+          </GridItem>
+        ))}
+    </Grid>
+  );
+}
+
 export default function ChampionsSummaryTabs() {
   const [tabIndex, setTabIndex] = useState(0);
+
+  const { data, status } = useQuery(championsTierQuery());
+
+  if (status !== 'success') {
+    return;
+  }
 
   return (
     <Tabs
@@ -43,6 +99,7 @@ export default function ChampionsSummaryTabs() {
 
       <TabPanels>
         <TabPanel>
+          {/* TODO: 백엔드에서 ALL 데이터를 받아올 수 있게 되면 이 부분을 삭제하고 밑에 표시해둔 곳 코멘트 해제 */}
           <Grid as="ul" gap="8px" templateColumns="repeat(6, 1fr)" justifyItems="center">
             {Object.entries(championIdKrNameMap)
               .sort(([, aName], [, bName]) => aName.localeCompare(bName))
@@ -80,12 +137,20 @@ export default function ChampionsSummaryTabs() {
               ))}
           </Grid>
         </TabPanel>
-        {/* TODO: 챔피언을 포지션별로 받아올 수 있는 백엔드 API 필요할듯 */}
-        <TabPanel>TOP</TabPanel>
-        <TabPanel>JGL</TabPanel>
-        <TabPanel>MID</TabPanel>
-        <TabPanel>BTM</TabPanel>
-        <TabPanel>SUP</TabPanel>
+        {[
+          // TODO: 백엔드에서 ALL 데이터를 받아올 수 있게 되면 윗 부분을 삭제하고 밑에 코드 코멘트 해제
+          // data.data.champions.ALL,
+          data.data.champions.TOP,
+          data.data.champions.JUNGLE,
+          data.data.champions.MIDDLE,
+          data.data.champions.BOTTOM,
+          data.data.champions.UTILITY,
+        ].map((champions, i) => (
+          // 위의 배열의 순서는 런타임에서 변경될 일이 절대 없기 때문에 인덱스를 key로 사용
+          <TabPanel key={i}>
+            <ChampionsSummaryTab champions={champions} />
+          </TabPanel>
+        ))}
       </TabPanels>
     </Tabs>
   );


### PR DESCRIPTION
## Summary
`/champions` 페이지 왼쪽의 챔피언 리스트 탭에 탑, 정글 등의 라인 정보를 채웠습니다.

## Describe your changes
- [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=2914-35864&mode=design&t=DSBgCgpMgf3bJggR-4)
- 작동 영상:

	[asdf.webm](https://github.com/gnimty/frontend-gnimty/assets/72999818/ef7deeb4-c3e1-4fee-b5eb-b07f7c58c7c1)
