### PR TITLE
fix: use mainStyleId

### DIFF
--- a/src/components/pages/champions/Runes.tsx
+++ b/src/components/pages/champions/Runes.tsx
@@ -37,7 +37,7 @@ export default function Runes({ perkBuilds }: RunesProps) {
               onClick={() => setTabIndex(index)}
             >
               <HStack gap="4px">
-                <Perk type="main" perkStyleId={perkBuild.primaryStyleId} />
+                <PerkImage perkId={perkBuild.mainStyleId} width="40" height="40" />
                 <Perk type="sub" perkStyleId={perkBuild.subStyleId} />
               </HStack>
               <HStack gap="8px">


### PR DESCRIPTION
## Summary

- 아래 이미지(현재)에서, 표기되는 메인을 핵심 룬으로 변경하였습니다

## Describe your changes

-

![image](https://github.com/gnimty/frontend-gnimty/assets/75024621/2533367d-d7f9-472c-b7a7-73780cd4142f)
