### PR TITLE
fix: fill empty champion image

### DIFF
--- a/src/components/duo/SummonerCard.tsx
+++ b/src/components/duo/SummonerCard.tsx
@@ -1,9 +1,7 @@
 import { IconButton } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 
-import championIdEnNameMap from '@/apis/constants/championIdEnNameMap';
 import type { RecommendedSummonersEntry } from '@/apis/types';
-import championIconUrl from '@/apis/utils/championIconUrl';
 import profileIconUrl from '@/apis/utils/profileIconUrl';
 import shortTierName from '@/apis/utils/shortTierName';
 import Chat from '@/assets/icons/system/chat.svg';
@@ -16,6 +14,8 @@ import PositionImage from '@/components/common/position-image/PositionImage';
 import StatusIndicator from '@/components/common/StatusIndicator';
 import TierImage from '@/components/common/TierImage';
 import copyText from '@/utils/copyText';
+
+import ChampionImagesFiller from '../common/ChampionImagesFiller';
 
 const CardWrapper = styled.div<{ $open: boolean }>`
   width: 352px;
@@ -202,32 +202,12 @@ export default function SummonerCard({ open, toggle, summoner, refObject, openCh
         </CardColumn>
       </CardHeader>
       <CardBody $flexColumn="true" $open={open} $gap={16}>
-        <CardColumn $gap={8}>
-          {frequentChampionId1 && (
-            <IconImage
-              src={championIconUrl(championIdEnNameMap[frequentChampionId1])}
-              width={32}
-              height={32}
-              alt="icon"
-            />
-          )}
-          {frequentChampionId2 && (
-            <IconImage
-              src={championIconUrl(championIdEnNameMap[frequentChampionId2])}
-              width={32}
-              height={32}
-              alt="icon"
-            />
-          )}
-          {frequentChampionId3 && (
-            <IconImage
-              src={championIconUrl(championIdEnNameMap[frequentChampionId3])}
-              width={32}
-              height={32}
-              alt="icon"
-            />
-          )}
-        </CardColumn>
+        <ChampionImagesFiller
+          championIds={[frequentChampionId1, frequentChampionId2, frequentChampionId3]}
+          imagesSizePx={32}
+          gap="8px"
+          w="full"
+        />
         <CardColumn>
           <SummonerDetail>{introduction}</SummonerDetail>
         </CardColumn>

--- a/src/components/pages/main/UserCardLandscape.style.tsx
+++ b/src/components/pages/main/UserCardLandscape.style.tsx
@@ -82,13 +82,6 @@ export const positionItem = css({
   display: 'flex',
 });
 
-export const champions = css({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '8px',
-  width: '112px',
-});
-
 export const championItem = css({
   display: 'flex',
 });

--- a/src/components/pages/main/UserCardLandscape.tsx
+++ b/src/components/pages/main/UserCardLandscape.tsx
@@ -1,13 +1,11 @@
 import Image from 'next/image';
 
-import championIdEnNameMap from '@/apis/constants/championIdEnNameMap';
-import championIdKrNameMap from '@/apis/constants/championIdKrNameMap';
 import type { RecommendedSummonersEntry } from '@/apis/types';
-import championIconUrl from '@/apis/utils/championIconUrl';
 import profileIconUrl from '@/apis/utils/profileIconUrl';
 import shortTierName from '@/apis/utils/shortTierName';
 import Chat from '@/assets/icons/system/chat.svg';
 import Copy from '@/assets/icons/system/copy.svg';
+import ChampionImagesFiller from '@/components/common/ChampionImagesFiller';
 import PositionImage from '@/components/common/position-image/PositionImage';
 import StatusIndicator from '@/components/common/StatusIndicator';
 import TierImage from '@/components/common/TierImage';
@@ -76,21 +74,12 @@ export default function UserCardLandscape(props: UserCardLandscapeProps) {
           </li>
         ))}
       </ol>
-      <ol css={style.champions}>
-        {[summoner.frequentChampionId1, summoner.frequentChampionId2, summoner.frequentChampionId3].map(
-          (championId) => (
-            <li key={championId} css={style.championItem}>
-              <Image
-                src={championIconUrl(championIdEnNameMap[championId])}
-                alt={championIdKrNameMap[championId]}
-                width={32}
-                height={32}
-                css={style.championImage}
-              />
-            </li>
-          ),
-        )}
-      </ol>
+      <ChampionImagesFiller
+        championIds={[summoner.frequentChampionId1, summoner.frequentChampionId2, summoner.frequentChampionId3]}
+        imagesSizePx={32}
+        w="112px"
+        gap="8px"
+      />
       <p css={style.introduction}>{summoner.introduction}</p>
       <button type="button" aria-label="채팅하기" onClick={handleChatButtonClick} css={style.chatButton}>
         <Chat width={24} height={24} aria-hidden css={{ display: 'block', lineHeight: 0 }} />

--- a/src/components/pages/rankings/RankingsTable.tsx
+++ b/src/components/pages/rankings/RankingsTable.tsx
@@ -2,12 +2,10 @@ import { Link } from '@chakra-ui/next-js';
 import { Box, Flex, Table, Tbody, Td, Text, Th, Thead, Tr } from '@chakra-ui/react';
 import Image from 'next/image';
 
-import championIdEnNameMap from '@/apis/constants/championIdEnNameMap';
-import championIdKrNameMap from '@/apis/constants/championIdKrNameMap';
 import type { SummonerRankDto } from '@/apis/types';
-import championIconUrl from '@/apis/utils/championIconUrl';
 import profileIconUrl from '@/apis/utils/profileIconUrl';
 import shortTierName from '@/apis/utils/shortTierName';
+import ChampionImagesFiller from '@/components/common/ChampionImagesFiller';
 import PositionImage from '@/components/common/position-image/PositionImage';
 import TierImage from '@/components/common/TierImage';
 
@@ -121,18 +119,13 @@ export default function RankingsTable(props: RankingsTableProps) {
                   <Box flex="1 1 0" bg="red800" />
                 </Flex>
               </Td>
-              <Td w="112px" display="flex" gap="8px">
-                {rank.tierInfo.mostChampionIds.map((id) => (
-                  <Image
-                    key={id}
-                    src={championIconUrl(championIdEnNameMap[id])}
-                    width={32}
-                    height={32}
-                    alt={championIdKrNameMap[id]}
-                    css={{ borderRadius: '9999px' }}
-                  />
-                ))}
-              </Td>
+              <ChampionImagesFiller
+                as="td"
+                championIds={rank.tierInfo.mostChampionIds}
+                imagesSizePx={32}
+                w="112px"
+                gap="8px"
+              />
             </Tr>
           );
         })}

--- a/src/components/pages/rankings/TopThreeCard.tsx
+++ b/src/components/pages/rankings/TopThreeCard.tsx
@@ -2,15 +2,14 @@ import { Link } from '@chakra-ui/next-js';
 import { Box, Flex, HStack, Text } from '@chakra-ui/react';
 import Image from 'next/image';
 
-import championIdEnNameMap from '@/apis/constants/championIdEnNameMap';
 import type { SummonerRankDto } from '@/apis/types';
-import championIconUrl from '@/apis/utils/championIconUrl';
 import championSplashUrl from '@/apis/utils/championSplashUrl';
 import profileIconUrl from '@/apis/utils/profileIconUrl';
 import shortTierName from '@/apis/utils/shortTierName';
 import firstPlaceFrame from '@/assets/images/first-place-frame.png';
 import secondPlaceFrame from '@/assets/images/second-place-frame.png';
 import thirdPlaceFrame from '@/assets/images/third-place-frame.png';
+import ChampionImagesFiller from '@/components/common/ChampionImagesFiller';
 import PositionImage from '@/components/common/position-image/PositionImage';
 import TierImage from '@/components/common/TierImage';
 
@@ -115,20 +114,7 @@ export default function TopThreeCard(props: TopThreeCardProps) {
               ))}
             </HStack>
           </Flex>
-          <HStack gap="8px">
-            {summonerRank.tierInfo.mostChampionIds.map((championId) => (
-              <Image
-                key={championId}
-                src={championIconUrl(championIdEnNameMap[championId])}
-                alt=""
-                width={32}
-                height={32}
-                css={{
-                  borderRadius: '999px',
-                }}
-              />
-            ))}
-          </HStack>
+          <ChampionImagesFiller championIds={summonerRank.tierInfo.mostChampionIds} imagesSizePx={32} gap="8px" />
           <HStack gap="4px">
             <Flex gap="2px" textStyle="t2" fontWeight="normal" color="gray600">
               <Box>W</Box>


### PR DESCRIPTION
## Summary
챔피언 이미지가 3개 나란히 있는 곳들은 API 응답으로 3개 미만이 왔을 때 빈 회색 원으로 채우도록 했습니다.

## Describe your changes
|변경한 곳|Before|After|
|---|---|---|
|메인|![main-before](https://github.com/gnimty/frontend-gnimty/assets/72999818/2abffc87-926a-4ce6-b50a-855eb9f9333a)|![main-after](https://github.com/gnimty/frontend-gnimty/assets/72999818/8a62133c-ecdb-417e-9b78-3e16b48d225c)|
|듀오|![duo-before](https://github.com/gnimty/frontend-gnimty/assets/72999818/7502e68d-f8d8-4ac1-913d-a19a75eab337)|![duo-after](https://github.com/gnimty/frontend-gnimty/assets/72999818/c901d769-95c0-4c5e-a546-54a229dc0b44)|
|소환사 랭킹 1|![summoner-ranking1-before](https://github.com/gnimty/frontend-gnimty/assets/72999818/85060f74-c108-4ab3-a44b-c4ab1d3f5b26)|![summoner-ranking1-after](https://github.com/gnimty/frontend-gnimty/assets/72999818/3f0676bf-8863-40d0-a5bf-0217940d1e26)|
|소환사 랭킹 2|![summoner-ranking2-before](https://github.com/gnimty/frontend-gnimty/assets/72999818/7ff136d9-5ada-4d22-8276-6946d2bc8bc1)|![summoner-ranking2-after](https://github.com/gnimty/frontend-gnimty/assets/72999818/9bae4c44-a56c-458a-b0fd-f6598cdef828)|
