### PR TITLE
refactor: zustand for AccountModal open state

### DIFF
--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,5 +1,4 @@
-import { useDisclosure } from '@chakra-ui/hooks';
-import { Button, Flex, IconButton } from '@chakra-ui/react';
+import { Button, Flex, IconButton, useDisclosure } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
@@ -14,6 +13,7 @@ import { useAuthContext } from '@/contexts/AuthContext';
 
 import ActiveLink from '../common/ActiveLink';
 import SummonerSearchBar from '../common/SummonerSearchBar';
+import { useAccountModalStore } from '../pages/account/accountModalStore';
 import RecommendsModal from '../recommends/Recommends';
 
 import * as style from './Header.style';
@@ -27,7 +27,7 @@ const links = [
 ];
 
 export default function Header() {
-  const { isOpen: isOpenLoginModal, onOpen: onOpenLoginModal, onClose: onCloseLoginModal } = useDisclosure();
+  const openAccountModal = useAccountModalStore((s) => s.open);
   const { isOpen: isOpenRecommends, onOpen: onOpenRecommends, onClose: onCloseRecommends } = useDisclosure();
   const { isAuthenticated, setIsAuthenticated } = useAuthContext();
   const { data: myInfoData } = useQuery(getMyInfoQuery());
@@ -93,12 +93,12 @@ export default function Header() {
             </Flex>
           </Flex>
         ) : (
-          <Button variant="default" size="md" width="80px" onClick={onOpenLoginModal}>
+          <Button variant="default" size="md" width="80px" onClick={openAccountModal}>
             로그인
           </Button>
         )}
       </header>
-      <AccountModal isOpen={isOpenLoginModal} onClose={onCloseLoginModal} />
+      <AccountModal />
       <RecommendsModal isOpen={isOpenRecommends} onClose={onCloseRecommends} />
     </>
   );

--- a/src/components/pages/account/AccountModal.tsx
+++ b/src/components/pages/account/AccountModal.tsx
@@ -5,16 +5,17 @@ import Exit from '@/assets/icons/system/exit.svg';
 import AccountModalBody from '@/components/pages/account/AccountModalBody';
 import { AccountModalPageProvider } from '@/contexts/AccountModalPageContext';
 
-interface AccountModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-}
+import { useAccountModalStore } from './accountModalStore';
+
 export const MAIL_CODE_CHECK_TIME = 180 as const; // 메일 인증 코드 대기 시간
 export const MAIL_SEND_CHECK_TIME = 170 as const; // 메일을 받지 못했나요 메시지 렌더링 시간
 
-export default function AccountModal({ isOpen, onClose }: AccountModalProps) {
+export default function AccountModal() {
+  const isOpen = useAccountModalStore((s) => s.isOpen);
+  const close = useAccountModalStore((s) => s.close);
+
   return (
-    <Modal closeOnOverlayClick={false} isOpen={isOpen} onClose={onClose} scrollBehavior="inside" isCentered>
+    <Modal closeOnOverlayClick={false} isOpen={isOpen} onClose={close} scrollBehavior="inside" isCentered>
       <ModalOverlay />
       <ModalContent maxW="480px" maxH="760px" px="40px" py="60px" backgroundColor="white">
         <IconButton
@@ -24,10 +25,10 @@ export default function AccountModal({ isOpen, onClose }: AccountModalProps) {
           top="24px"
           right="24px"
           aria-label="Close"
-          onClick={onClose}
+          onClick={close}
           icon={<Exit />}
         />
-        <AccountModalPageProvider onClose={onClose}>
+        <AccountModalPageProvider onClose={close}>
           <AccountModalBody />
         </AccountModalPageProvider>
       </ModalContent>

--- a/src/components/pages/account/accountModalStore.ts
+++ b/src/components/pages/account/accountModalStore.ts
@@ -1,0 +1,33 @@
+import { createStore } from 'zustand';
+
+import createSSRStore from '@/utils/createSSRStore';
+
+interface AccountModalState {
+  isOpen: boolean;
+}
+
+interface AccountModalActions {
+  open: () => void;
+  close: () => void;
+}
+
+export type AccountModalStore = AccountModalState & AccountModalActions;
+
+const defaultInitState: AccountModalState = {
+  isOpen: false,
+};
+
+const createAccountModalStore = (initState = defaultInitState) =>
+  createStore<AccountModalStore>()((set) => ({
+    ...initState,
+    open: () => {
+      set({ isOpen: true });
+    },
+    close: () => {
+      set({ isOpen: false });
+    },
+  }));
+
+const [AccountModalStoreProvider, useAccountModalStore] = createSSRStore(createAccountModalStore);
+
+export { AccountModalStoreProvider, useAccountModalStore };

--- a/src/providers/StoreProviders.tsx
+++ b/src/providers/StoreProviders.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from 'react';
 
+import { AccountModalStoreProvider } from '@/components/pages/account/accountModalStore';
 import {
   FavoriteSummonerMapStoreContext,
   FavoriteSummonerMapStoreProvider,
@@ -21,15 +22,17 @@ export default function StoreProviders(props: StoreProvidersProps) {
   return (
     <RecentSearchesStoreProvider>
       <FavoriteSummonerMapStoreProvider>
-        {/* FIXME */}
-        {/* @ts-expect-error 나중에 createSSRStore() 수정 혹은 다른 방법을 통해 타이핑 작동하게 하기 */}
-        <PersistStoreStorageProvider StoreContext={RecentSearchesStoreContext}>
+        <AccountModalStoreProvider>
           {/* FIXME */}
           {/* @ts-expect-error 나중에 createSSRStore() 수정 혹은 다른 방법을 통해 타이핑 작동하게 하기 */}
-          <PersistStoreStorageProvider StoreContext={FavoriteSummonerMapStoreContext}>
-            {children}
+          <PersistStoreStorageProvider StoreContext={RecentSearchesStoreContext}>
+            {/* FIXME */}
+            {/* @ts-expect-error 나중에 createSSRStore() 수정 혹은 다른 방법을 통해 타이핑 작동하게 하기 */}
+            <PersistStoreStorageProvider StoreContext={FavoriteSummonerMapStoreContext}>
+              {children}
+            </PersistStoreStorageProvider>
           </PersistStoreStorageProvider>
-        </PersistStoreStorageProvider>
+        </AccountModalStoreProvider>
       </FavoriteSummonerMapStoreProvider>
     </RecentSearchesStoreProvider>
   );


### PR DESCRIPTION
## Summary
헤더의 로그인 버튼 외에서도 로그인 모달을 열 수 있게 (예: [피그마 링크](https://www.figma.com/file/TNHy0eQfP8gy0CwgIZ7Xbe/OSR?type=design&node-id=4239-18894&mode=design&t=FFGrzmcGr7kshwnU-4)) `<AccountModal>`을 zustand를 통해 관리합니다. 재렌더링 때문에 Context는 사용하지 않았습니다.
