### PR TITLE
fix: patch, detailpage championName

### DIFF
--- a/src/components/pages/champions/DetailPage.tsx
+++ b/src/components/pages/champions/DetailPage.tsx
@@ -3,6 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
+import championIdEnNameMap from '@/apis/constants/championIdEnNameMap';
+import champions from '@/apis/constants/champions';
 import championDetailQuery from '@/apis/queries/championDetailQuery';
 import championSkillsQuery from '@/apis/queries/championSkillsQuery';
 import type { Position, PositionFilter } from '@/apis/types';
@@ -24,10 +26,15 @@ interface DetailPageProps {
 
 export default function DetailPage({ championEnName, queryLane }: DetailPageProps) {
   const router = useRouter();
-  const capitalizedChampionEnName = championEnName.charAt(0).toUpperCase() + championEnName.slice(1);
+  const championId = champions.find(
+    (champion) => champion.enName.toLowerCase() === championEnName.toLowerCase(),
+  )?.championId;
+  const championName = championId
+    ? championIdEnNameMap[championId]
+    : championEnName.charAt(0).toUpperCase() + championEnName.slice(1);
   const [lane, setLane] = useState<PositionFilter | 'UNKNOWN' | ''>(queryLane ?? '');
-  const { data, error } = useQuery(championDetailQuery({ championEnName: capitalizedChampionEnName, lane }));
-  const { data: skillData } = useQuery(championSkillsQuery({ championEnName: capitalizedChampionEnName }));
+  const { data, error } = useQuery(championDetailQuery({ championEnName: championName, lane }));
+  const { data: skillData } = useQuery(championSkillsQuery({ championEnName: championName }));
   const handleUpdateLane = (lane: PositionFilter) => setLane(lane);
 
   useEffect(() => {
@@ -58,7 +65,7 @@ export default function DetailPage({ championEnName, queryLane }: DetailPageProp
       {/* 2 룬*/}
       <Runes perkBuilds={data?.data.perkBuilds} />
       {/* 3 스킬 빌드 */}
-      <SkillBuild skillBuilds={data?.data.skillBuilds} skillData={skillData?.data[capitalizedChampionEnName].spells} />
+      <SkillBuild skillBuilds={data?.data.skillBuilds} skillData={skillData?.data[championName].spells} />
       {/* 4 소환사 주문, 시작 아이템, 첫 귀환, 신발 */}
       <HStack w="full" gap="12px" justify="space-between">
         {/* 소환사 주문 */}

--- a/src/components/pages/champions/DetailPage.tsx
+++ b/src/components/pages/champions/DetailPage.tsx
@@ -29,9 +29,10 @@ export default function DetailPage({ championEnName, queryLane }: DetailPageProp
   const championId = champions.find(
     (champion) => champion.enName.toLowerCase() === championEnName.toLowerCase(),
   )?.championId;
-  const championName = championId
-    ? championIdEnNameMap[championId]
-    : championEnName.charAt(0).toUpperCase() + championEnName.slice(1);
+  const championName =
+    championId !== undefined
+      ? championIdEnNameMap[championId]
+      : championEnName.charAt(0).toUpperCase() + championEnName.slice(1);
   const [lane, setLane] = useState<PositionFilter | 'UNKNOWN' | ''>(queryLane ?? '');
   const { data, error } = useQuery(championDetailQuery({ championEnName: championName, lane }));
   const { data: skillData } = useQuery(championSkillsQuery({ championEnName: championName }));

--- a/src/components/pages/champions/PatchNotes.tsx
+++ b/src/components/pages/champions/PatchNotes.tsx
@@ -10,9 +10,9 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 import { Fragment } from 'react';
 
+import championIdEnNameMap from '@/apis/constants/championIdEnNameMap';
 import type { ChampionPatch } from '@/apis/types';
 import ChampionIcon from '@/components/common/ChampionIcon';
 
@@ -46,9 +46,8 @@ interface PatchInfoProps {
 }
 
 function PatchInfo({ patch }: PatchInfoProps) {
-  const { version, target, targetImgUrl, changes } = patch;
-  const router = useRouter();
-  const { championEnName } = router.query;
+  const { championId, version, target, targetImgUrl, changes } = patch;
+  const championName = championIdEnNameMap[championId];
   return (
     <AccordionItem bg="white">
       <AccordionButton
@@ -76,7 +75,7 @@ function PatchInfo({ patch }: PatchInfoProps) {
               />
             </Box>
           ) : (
-            <ChampionIcon championEnName={championEnName as string} width={40} height={40} />
+            <ChampionIcon championEnName={championName} width={40} height={40} />
           )}
           <VStack gap="4px" justify="flex-start">
             <Text textStyle="t1" fontWeight="700">

--- a/src/components/pages/champions/PatchNotes.tsx
+++ b/src/components/pages/champions/PatchNotes.tsx
@@ -10,6 +10,7 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import { Fragment } from 'react';
 
 import type { ChampionPatch } from '@/apis/types';
@@ -45,8 +46,9 @@ interface PatchInfoProps {
 }
 
 function PatchInfo({ patch }: PatchInfoProps) {
-  const { enName, version, target, targetImgUrl, changes } = patch;
-  const capitalizedEnName = enName.charAt(0).toUpperCase() + enName.slice(1);
+  const { version, target, targetImgUrl, changes } = patch;
+  const router = useRouter();
+  const { championEnName } = router.query;
   return (
     <AccordionItem bg="white">
       <AccordionButton
@@ -74,7 +76,7 @@ function PatchInfo({ patch }: PatchInfoProps) {
               />
             </Box>
           ) : (
-            <ChampionIcon championEnName={capitalizedEnName} width={40} height={40} />
+            <ChampionIcon championEnName={championEnName as string} width={40} height={40} />
           )}
           <VStack gap="4px" justify="flex-start">
             <Text textStyle="t1" fontWeight="700">


### PR DESCRIPTION
## Summary

- patch에 포함된 enName drmundo를 캐피탈라이즈 하여 사용할 경우 DrMundo.png를 불러오지 못하는 이슈였습니다
- 해당 이슈와 동일한 현상이 /champions/{drmundo, Drmundo, DrMundo}로 접근할때에도 발생하고 있어 이를 수정하였습니다

## Describe your changes

-
