### PR TITLE
refactor: consolidate AuthContext logic

### DIFF
--- a/src/apis/useLogin.ts
+++ b/src/apis/useLogin.ts
@@ -1,8 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
 
 import type { BaseMutationProps } from '@/apis/httpRequest';
 import httpRequest from '@/apis/httpRequest';
-import { useAuthContext } from '@/contexts/AuthContext';
 
 interface UseLoginMutationProps extends BaseMutationProps<void, Error, LoginRequest> {}
 
@@ -18,17 +18,15 @@ async function login({ email, password }: LoginRequest): Promise<void> {
 }
 
 const useLogin = ({ onSuccess, onError }: UseLoginMutationProps) => {
-  const { setIsAuthenticated } = useAuthContext();
+  const router = useRouter();
+
   const mutation = useMutation({
     mutationFn: login,
     onSuccess: (response, variables, context) => {
       onSuccess?.(response, variables, context);
-      setIsAuthenticated(true);
+      router.reload();
     },
-    onError: (error, variables, context) => {
-      onError?.(error, variables, context);
-      setIsAuthenticated(false);
-    },
+    onError,
   });
 
   return { isPending: mutation.isPending, login: mutation.mutate };

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,7 +1,6 @@
 import { Button, Flex, IconButton, useDisclosure } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 
 import getMyInfoQuery from '@/apis/queries/getMyInfoQuery';
 import { logout } from '@/apis/useLogout';
@@ -29,13 +28,9 @@ const links = [
 export default function Header() {
   const openAccountModal = useAccountModalStore((s) => s.open);
   const { isOpen: isOpenRecommends, onOpen: onOpenRecommends, onClose: onCloseRecommends } = useDisclosure();
-  const { isAuthenticated, setIsAuthenticated } = useAuthContext();
+  const { isAuthenticated } = useAuthContext();
   const { data: myInfoData } = useQuery(getMyInfoQuery());
   const myInfo = myInfoData?.data;
-
-  useEffect(() => {
-    setIsAuthenticated(!!myInfo);
-  }, [myInfo, setIsAuthenticated]);
 
   const router = useRouter();
   const onSelect = async (value: string) => {
@@ -63,7 +58,7 @@ export default function Header() {
           ))}
         </nav>
 
-        {isAuthenticated ? (
+        {isAuthenticated && myInfo !== undefined ? (
           <Flex position="relative" gap="8px">
             {router.pathname !== '/' && <SummonerSearchBar size="in-header" />}
             <Flex w="40px" h="40px" justifyContent="center" alignContent="center">

--- a/src/contexts/AuthContext.ts
+++ b/src/contexts/AuthContext.ts
@@ -1,8 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
 import constate from 'constate';
-import { useState } from 'react';
+
+import getMyInfoQuery from '@/apis/queries/getMyInfoQuery';
 
 export const [AuthContextProvider, useAuthContext] = constate(() => {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const { status } = useQuery(getMyInfoQuery());
+  const isAuthenticated = status === 'success';
 
-  return { isAuthenticated, setIsAuthenticated };
+  return { isAuthenticated };
 });

--- a/src/pages/redirect.tsx
+++ b/src/pages/redirect.tsx
@@ -1,11 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 import httpRequest from '@/apis/httpRequest';
-import getMyInfoQuery from '@/apis/queries/getMyInfoQuery';
-import { useAuthContext } from '@/contexts/AuthContext';
 
 import type { GetServerSideProps } from 'next';
 
@@ -15,14 +12,12 @@ interface RedirectPageProps {
 
 function Redirect({ redirectUrl }: RedirectPageProps) {
   const router = useRouter();
-  const { data: myInfoData } = useQuery(getMyInfoQuery());
-  const checkToken = myInfoData?.data;
-  const { setIsAuthenticated } = useAuthContext();
 
   useEffect(() => {
-    setIsAuthenticated(!!checkToken);
-    router.replace(redirectUrl).then();
-  }, [checkToken, redirectUrl, router, setIsAuthenticated]);
+    if (router.isReady) {
+      router.replace(redirectUrl);
+    }
+  }, [redirectUrl, router]);
 
   return <></>;
 }


### PR DESCRIPTION
## Summary
`<AuthContext>` 관련 로직들이 흩어져 있던 것을 한 곳으로 뭉쳤습니다.

## Describe your changes
- `<AuthContext>` 관련 로직들이 흩어져 있던 것을 한 곳으로 뭉쳤습니다.
- 편한 상태 관리를 위해 로그인 이후에 페이지가 새로고침 되도록 했습니다.
- 페이지 새로고침, 이동 등의 이유로 `isAuthenticated`를 `<AuthContext>` 외부에서 업데이트 할 필요가 없어졌으므로 `setIsAuthenticated`를 삭제했습니다.
