### PR TITLE
ci: new line long command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,11 @@ jobs:
           key: ${{ secrets.DEPLOY_KEY }}
           script: |
             cd ${{ vars.DEPLOY_PATH }}
-            docker build --build-arg API_BASE_URL=${{ vars.DEV_API_BASE_URL }} --build-arg GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }} --build-arg KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }} . -t ${{ needs.deploy-setup.outputs.docker_image }}
+            docker build \
+              --build-arg API_BASE_URL=${{ vars.DEV_API_BASE_URL }} \
+              --build-arg GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }} \
+              --build-arg KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }} \
+              . -t ${{ needs.deploy-setup.outputs.docker_image }}
             docker stop ${{ needs.deploy-setup.outputs.container_name }}
             docker rm ${{ needs.deploy-setup.outputs.container_name }}
             docker run -p 3000:3000 -d --name=${{ needs.deploy-setup.outputs.container_name }} ${{ needs.deploy-setup.outputs.docker_image }}


### PR DESCRIPTION
## Summary
```log
======CMD======
cd /home/***/frontend-gnimty
docker build --build-arg API_BASE_URL=https://gnimty.kro.kr/ --build-arg GOOGLE_CLIENT_ID=***
 --build-arg KAKAO_CLIENT_ID=*** . -t frontend-gnimty:dev
docker stop frontend-gnimty-dev
docker rm frontend-gnimty-dev
docker run -p 3000:3000 -d --name=frontend-gnimty-dev frontend-gnimty:dev

======END======
err: DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
err:             Install the buildx component to build images with BuildKit:
err:             https://docs.docker.com/go/buildx/
err: "docker build" requires exactly 1 argument.
err: See 'docker build --help'.
err: Usage:  docker build [OPTIONS] PATH | URL | -
err: Build an image from a Dockerfile
err: bash: line 3: --build-arg: command not found
out: frontend-gnimty-dev
out: frontend-gnimty-dev
out: 8bef9854e5402ba5bfbe172e704f0dec95cb7c41de0f86a3c8b1e50943dcd7ae
==============================================
```
배포 워크플로우에서 위 같은 에러가 나가지고 일단 고쳐봤습니다.
