### PR TITLE
refactor: pass rewrites param to query param

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,9 @@
+// @ts-check
+
+// TODO: 현재 의미론상 정확히 일치하지 않음 후에 작동방식을 변경하거나 환경변수 등으로 설정해야함
+/** OAuth 리다이렉트에 사용할 origin */
+const redirectURI = `${process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/api$/, '')}/redirect`;
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   rewrites:
@@ -13,23 +19,28 @@ const nextConfig = {
     return [
       {
         source: '/oauth/google/:state*',
-        destination: `https://accounts.google.com/o/oauth2/v2/auth?client_id=${
-          process.env.GOOGLE_CLIENT_ID
-        }&redirect_uri=${process.env.NEXT_PUBLIC_API_BASE_URL.replace(
-          /\/api$/,
-          '',
-        )}/redirect&response_type=code&scope=email&state=/:state*`,
+        destination:
+          'https://accounts.google.com/o/oauth2/v2/auth?' +
+          new URLSearchParams({
+            client_id: process.env.GOOGLE_CLIENT_ID ?? '',
+            redirect_uri: redirectURI,
+            response_type: 'code',
+            scope: 'email',
+          }).toString() +
+          '&state=:state*',
         basePath: false,
         permanent: true,
       },
       {
         source: '/oauth/kakao/:state*',
-        destination: `https://kauth.kakao.com/oauth/authorize?client_id=${
-          process.env.KAKAO_CLIENT_ID
-        }&redirect_uri=${process.env.NEXT_PUBLIC_API_BASE_URL.replace(
-          /\/api$/,
-          '',
-        )}/redirect&response_type=code&state=/:state*`,
+        destination:
+          'https://kauth.kakao.com/oauth/authorize?' +
+          new URLSearchParams({
+            client_id: process.env.KAKAO_CLIENT_ID ?? '',
+            redirect_uri: redirectURI,
+            response_type: 'code',
+          }).toString() +
+          '&state=:state*',
         basePath: false,
         permanent: true,
       },

--- a/src/pages/redirect.tsx
+++ b/src/pages/redirect.tsx
@@ -29,7 +29,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const encodeData = Array.isArray(state) ? state[0] : state ?? '/';
   try {
-    const { redirectUrl, target } = JSON.parse(decodeURIComponent(encodeData.substring(1))) as {
+    const { redirectUrl, target } = JSON.parse(decodeURIComponent(encodeData)) as {
       redirectUrl: string;
       target: 'google' | 'kakao';
     };


### PR DESCRIPTION
## Summary
next.config.js에 있던 OAuth 관련 코드를 좀 더 읽기 쉽게 바꾸고 `state`를 쿼리 파라미터에 전달되게 해 본래 작성의도와 가깝게 코드를 리팩터링했습니다.

## Describe your changes
- 아예 `rewrites`등을 없애는 등의 시도를 했었고 실제로 잘 작동했지만 일단은 기존 코드와 가깝게 변경하는 게 좋을듯 하여 이렇게 리팩터링을 진행했습니다.
- 후에는 next.js의 서버 기능 의존성을 없애기 위해 `rewrites`를 없애는 게 좋을 것 같습니다.
- 또한 `rewrites`를 없애는 작업과 동시에 OAuth `state` 파라미터의 본래 용도인 CSRF 방지를 위해 후에는 백엔드 분들께 요청해 관련로직을 백엔드 API로 옮기는 게 좋을 것 같습니다.

