### PR TITLE
fix: 채팅에서 유저 차단 시 채팅나가기, error code 409인 경우 처리

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -87,6 +87,14 @@ function ToggleMenu() {
   const { selectedChatRoomNo, exitChatRoom, chatRooms } = useChatContext();
   const { mutateAsync: memberBlockAsync } = useMutation({
     mutationFn: memberBlock,
+    onSuccess() {
+      exitChatRoom(selectedChatRoomNo!);
+    },
+    onError(error) {
+      if (error.response?.data.status.code === 409) {
+        alert('이미 차단한 유저입니다.');
+      }
+    },
   });
   const otherUserId = chatRooms.find((room) => room.chatRoomNo === selectedChatRoomNo)?.otherUser.userId;
   const handleUserBlock = async () => {


### PR DESCRIPTION
## Summary

- 채팅에서 유저 차단 부분을 수정했습니다.
- 성공시 나가기, 차단요청 중복 시 에러(이 부분은 차단된 유저가 다시 채팅목록에 들어오는 경우가 아니라면 실행되지 않을 것 같기는 합니다)