### PR TITLE
Feature/recommended pick top section

### DIFF
--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -230,6 +230,7 @@ export interface RiotAccountEntry {
   frequentChampionId2Flex: number | null;
   frequentChampionId3Flex: number | null;
   iconId: number;
+  level: number;
 }
 
 export type OAuthProvider = 'GOOGLE' | 'KAKAO';

--- a/src/components/pages/main/search/SearchList.tsx
+++ b/src/components/pages/main/search/SearchList.tsx
@@ -10,10 +10,16 @@ const summonerAutoCompleteToSearchPopRowItems = (data: SummonerAutoCompleteRespo
 
 interface SearchListProps {
   keyword: string;
+  /**
+   * @description XButtonClick이 기본동작이 아닌 경우에 사용 (추천Pick 화면)
+   * @param summonerProfile
+   * @returns void
+   */
+  onCustomXButtonClick?: (summonerName: string) => void;
 }
 
 export default function SearchList(props: SearchListProps) {
-  const { keyword } = props;
+  const { keyword, onCustomXButtonClick } = props;
 
   const { data: items, status } = useQuery({
     ...summonerAutoCompleteQuery({ keyword }),
@@ -24,5 +30,5 @@ export default function SearchList(props: SearchListProps) {
     return;
   }
 
-  return <SearchPopBody items={items} />;
+  return <SearchPopBody items={items} onCustomXButtonClick={onCustomXButtonClick} />;
 }

--- a/src/components/pages/main/search/SearchList.tsx
+++ b/src/components/pages/main/search/SearchList.tsx
@@ -15,11 +15,11 @@ interface SearchListProps {
    * @param summonerProfile
    * @returns void
    */
-  onCustomXButtonClick?: (summonerName: string) => void;
+  onSelect?: (summonerName: string) => void;
 }
 
 export default function SearchList(props: SearchListProps) {
-  const { keyword, onCustomXButtonClick } = props;
+  const { keyword, onSelect } = props;
 
   const { data: items, status } = useQuery({
     ...summonerAutoCompleteQuery({ keyword }),
@@ -30,5 +30,5 @@ export default function SearchList(props: SearchListProps) {
     return;
   }
 
-  return <SearchPopBody items={items} onCustomXButtonClick={onCustomXButtonClick} />;
+  return <SearchPopBody items={items} onSelect={onSelect} />;
 }

--- a/src/components/pages/main/search/SearchPopBody.tsx
+++ b/src/components/pages/main/search/SearchPopBody.tsx
@@ -6,11 +6,11 @@ export interface SearchPopBodyProps {
   items: SearchPopRowItem[];
   textWhenEmpty?: string;
   onXButtonClick?: (puuid: string) => void;
-  onCustomXButtonClick?: (summonerName: string) => void;
+  onSelect?: (summonerName: string) => void;
 }
 
 export default function SearchPopBody(props: SearchPopBodyProps) {
-  const { textWhenEmpty, items, onXButtonClick, onCustomXButtonClick } = props;
+  const { textWhenEmpty, items, onXButtonClick, onSelect } = props;
 
   if (items.length === 0) {
     if (textWhenEmpty === undefined) {
@@ -32,16 +32,13 @@ export default function SearchPopBody(props: SearchPopBodyProps) {
         <SearchPopRow
           key={item.puuid}
           searchPopRowItem={item}
+          onSelect={onSelect}
           onXButtonClick={
-            onCustomXButtonClick !== undefined
+            onXButtonClick !== undefined
               ? () => {
-                  onCustomXButtonClick(`${item.summonerName}#${item.tagLine}`);
+                  onXButtonClick(item.puuid);
                 }
-              : onXButtonClick !== undefined
-                ? () => {
-                    onXButtonClick(item.puuid);
-                  }
-                : undefined
+              : undefined
           }
         />
       ))}

--- a/src/components/pages/main/search/SearchPopBody.tsx
+++ b/src/components/pages/main/search/SearchPopBody.tsx
@@ -6,10 +6,11 @@ export interface SearchPopBodyProps {
   items: SearchPopRowItem[];
   textWhenEmpty?: string;
   onXButtonClick?: (puuid: string) => void;
+  onCustomXButtonClick?: (summonerName: string) => void;
 }
 
 export default function SearchPopBody(props: SearchPopBodyProps) {
-  const { textWhenEmpty, items, onXButtonClick } = props;
+  const { textWhenEmpty, items, onXButtonClick, onCustomXButtonClick } = props;
 
   if (items.length === 0) {
     if (textWhenEmpty === undefined) {
@@ -32,11 +33,15 @@ export default function SearchPopBody(props: SearchPopBodyProps) {
           key={item.puuid}
           searchPopRowItem={item}
           onXButtonClick={
-            onXButtonClick !== undefined
+            onCustomXButtonClick !== undefined
               ? () => {
-                  onXButtonClick(item.puuid);
+                  onCustomXButtonClick(`${item.summonerName}#${item.tagLine}`);
                 }
-              : undefined
+              : onXButtonClick !== undefined
+                ? () => {
+                    onXButtonClick(item.puuid);
+                  }
+                : undefined
           }
         />
       ))}

--- a/src/components/pages/main/search/SearchPopRow.tsx
+++ b/src/components/pages/main/search/SearchPopRow.tsx
@@ -19,10 +19,11 @@ export interface SearchPopRowItem {
 export interface SearchPopRowProps {
   searchPopRowItem: SearchPopRowItem;
   onXButtonClick?: () => void;
+  onSelect?: (summonerName: string) => void;
 }
 
 export default function SearchPopRow(props: SearchPopRowProps) {
-  const { searchPopRowItem, onXButtonClick } = props;
+  const { searchPopRowItem, onXButtonClick, onSelect } = props;
 
   const favoriteSummonerMap = useFavoriteSummonerMapStore((state) => state.favoriteSummonerMap);
   const toggleFavoriteSummoner = useFavoriteSummonerMapStore((state) => state.toggleFavoriteSummoner);
@@ -31,40 +32,62 @@ export default function SearchPopRow(props: SearchPopRowProps) {
 
   return (
     <HStack w="full" justify="space-between">
-      <Link
-        href={`/summoners/${searchPopRowItem.summonerName}-${searchPopRowItem.tagLine}`}
-        display="flex"
-        alignItems="center"
-        gap="12px"
-        textDecor="none"
-      >
-        <ProfileImage iconId={searchPopRowItem.profileIconId} width={24} height={24} />
-        <HStack gap="4px">
-          <Text textStyle="t2" fontWeight="regular" color="gray800">
-            {searchPopRowItem.summonerName}
-          </Text>
-          <Text textStyle="body" fontWeight="regular" color="gray600">
-            #{searchPopRowItem.tagLine}
-          </Text>
-        </HStack>
-        {searchPopRowItem.isVerified && <VerifiedTag />}
-      </Link>
-      <HStack gap="12px">
-        <IconButton
-          aria-label={`즐겨찾기 ${isFavorite ? '취소' : '등록'}`}
-          onClick={() => {
-            toggleFavoriteSummoner(searchPopRowItem);
-          }}
-          display="inline-flex"
+      {onSelect ? (
+        <HStack
+          alignItems="center"
+          gap="12px"
+          cursor="pointer"
+          onClick={() => onSelect(`${searchPopRowItem.summonerName}-${searchPopRowItem.tagLine}`)}
         >
-          <FavoriteIcon isOn={isFavorite} width={20} height={20} />
-        </IconButton>
-        {onXButtonClick && (
-          <IconButton aria-label="최근 검색에서 삭제" onClick={onXButtonClick} display="inline-flex">
-            <ExitIcon width={20} height={20} />
-          </IconButton>
-        )}
-      </HStack>
+          <ProfileImage iconId={searchPopRowItem.profileIconId} width={24} height={24} />
+          <HStack gap="4px">
+            <Text textStyle="t2" fontWeight="regular" color="gray800">
+              {searchPopRowItem.summonerName}
+            </Text>
+            <Text textStyle="body" fontWeight="regular" color="gray600">
+              #{searchPopRowItem.tagLine}
+            </Text>
+          </HStack>
+          {searchPopRowItem.isVerified && <VerifiedTag />}
+        </HStack>
+      ) : (
+        <>
+          <Link
+            href={`/summoners/${searchPopRowItem.summonerName}-${searchPopRowItem.tagLine}`}
+            display="flex"
+            alignItems="center"
+            gap="12px"
+            textDecor="none"
+          >
+            <ProfileImage iconId={searchPopRowItem.profileIconId} width={24} height={24} />
+            <HStack gap="4px">
+              <Text textStyle="t2" fontWeight="regular" color="gray800">
+                {searchPopRowItem.summonerName}
+              </Text>
+              <Text textStyle="body" fontWeight="regular" color="gray600">
+                #{searchPopRowItem.tagLine}
+              </Text>
+            </HStack>
+            {searchPopRowItem.isVerified && <VerifiedTag />}
+          </Link>
+          <HStack gap="12px">
+            <IconButton
+              aria-label={`즐겨찾기 ${isFavorite ? '취소' : '등록'}`}
+              onClick={() => {
+                toggleFavoriteSummoner(searchPopRowItem);
+              }}
+              display="inline-flex"
+            >
+              <FavoriteIcon isOn={isFavorite} width={20} height={20} />
+            </IconButton>
+            {onXButtonClick && (
+              <IconButton aria-label="최근 검색에서 삭제" onClick={onXButtonClick} display="inline-flex">
+                <ExitIcon width={20} height={20} />
+              </IconButton>
+            )}
+          </HStack>
+        </>
+      )}
     </HStack>
   );
 }

--- a/src/components/pages/recommended-pick/RecommendedPickSelectSummoner.tsx
+++ b/src/components/pages/recommended-pick/RecommendedPickSelectSummoner.tsx
@@ -1,6 +1,12 @@
-import { VStack } from '@chakra-ui/react';
+import { Box, HStack, Text, VStack, Button } from '@chakra-ui/react';
+import { Fragment } from 'react';
 
 import type { ProfileEntry } from '@/apis/types';
+import profileIconUrl from '@/apis/utils/profileIconUrl';
+import shortTierName from '@/apis/utils/shortTierName';
+import ChampionIcon from '@/components/common/ChampionIcon';
+import IconImage from '@/components/common/IconImage';
+import TierImage from '@/components/common/TierImage';
 
 export interface RecommendedPickSelectSummonerProps {
   myProfile: ProfileEntry;
@@ -13,5 +19,107 @@ export default function RecommendedPickSelectSummoner(props: RecommendedPickSele
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { myProfile, onSummonerChange } = props;
 
-  return <VStack w="full">{myProfile.email}</VStack>;
+  return <HStack w="full" h="320px" gap="24px" />;
 }
+
+interface SummonerCardProps {
+  summonerType: 'me' | 'other';
+}
+
+function SummonerCard({ summonerType }: SummonerCardProps) {
+  return (
+    <VStack w="528px" h="full" bg="white" borderRadius="4px" p="20px" gap="20px">
+      <HStack w="full" h="78px" gap="12px">
+        <Box w="78px" h="78px" position="relative">
+          <IconImage width={78} height={78} radius={39} src={profileIconUrl(1)} alt="소환사 아이콘" />
+          <Box
+            position="absolute"
+            bottom="0"
+            left="0"
+            minW="38px"
+            p="1px 8px"
+            borderRadius="20px"
+            bgColor="gray800"
+            color="white"
+            textStyle="body"
+          >
+            000
+          </Box>
+        </Box>
+        <VStack w="full" h="full" gap="12px">
+          <HStack w="full" gap="12px">
+            <Text textStyle="h2" color="gray800" fontWeight="700">
+              T1 Gumayusi
+            </Text>
+            <Text textStyle="h3" color="gray600" fontWeight="400">
+              #KR1
+            </Text>
+          </HStack>
+          <HStack w="full" gap="8px">
+            <TierImage tier="unknown" width={28} height={28} />
+            <Text textStyle="h3" color="gray800" fontWeight="700">
+              {shortTierName('grandmaster')}
+            </Text>
+            <Text textStyle="h3" color="gray500" fontWeight="400">
+              0,000LP
+            </Text>
+          </HStack>
+        </VStack>
+        <VStack w="full" h="full" borderRadius="8px" p="16px 20px" gap="12px" align="flex-start">
+          <HStack gap="20px">
+            <Text textStyle="t1" color="gray700" fontWeight="700">
+              20전 14승 6패
+            </Text>
+            <Text textStyle="t1" color={championScoreColor(3.3)} fontWeight="700">
+              3.3평점
+            </Text>
+          </HStack>
+          <HStack w="full" justify="space-between" bgColor="gray100">
+            <HStack gap="12px">
+              {Array(3).map((_, index) => (
+                <Fragment key={index}>
+                  <ChampionIcon championEnName="Xerath" width={48} height={48} radius={24} />
+                  <VStack align="flex-start" gap="4px">
+                    <Text textStyle="t1" color="gray800" fontWeight="700">
+                      100%
+                    </Text>
+                    <Text textStyle="t2" color={championScoreColor(8.0)} fontWeight="400">
+                      8.00 평점
+                    </Text>
+                  </VStack>
+                </Fragment>
+              ))}
+            </HStack>
+          </HStack>
+        </VStack>
+        {summonerType === 'other' && (
+          <Button
+            w="full"
+            h="48px"
+            bgColor="gray800"
+            p="14px 12px"
+            borderRadius="4px"
+            textStyle="t2"
+            color="white"
+            fontWeight="700"
+            textAlign="center"
+          >
+            다른 소환사로 변경하기
+          </Button>
+        )}
+      </HStack>
+    </VStack>
+  );
+}
+
+const championScoreColor = (score: number | string) => {
+  if (typeof score === 'number') {
+    if (score < 3) {
+      return 'gray600';
+    }
+    if (score < 5) {
+      return 'green800';
+    }
+  }
+  return 'orange800';
+};

--- a/src/components/pages/recommended-pick/RecommendedPickSelectSummoner.tsx
+++ b/src/components/pages/recommended-pick/RecommendedPickSelectSummoner.tsx
@@ -2,8 +2,9 @@ import { Box, HStack, Text, VStack, Button } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { Fragment, useState } from 'react';
 
-import summonerInfoQuery from '@/apis/queries/summonerInfoQuery';
-import type { ProfileEntry, SummonerDto } from '@/apis/types';
+import championIdEnNameMap from '@/apis/constants/championIdEnNameMap';
+import summonerMatchesInfoQuery from '@/apis/queries/summonerMatchesInfoQuery';
+import type { MatchSummaryDto, ProfileEntry, SummonerDto } from '@/apis/types';
 import profileIconUrl from '@/apis/utils/profileIconUrl';
 import shortTierName from '@/apis/utils/shortTierName';
 import ChampionIcon from '@/components/common/ChampionIcon';
@@ -22,19 +23,41 @@ export default function RecommendedPickSelectSummoner(props: RecommendedPickSele
   // TODO: use onSummonerChange
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { myProfile, onSummonerChange } = props;
+  const mainAccount = myProfile.riotDependentInfo.riotAccounts.find((account) => account.isMain);
+  const { data: mainAccountMatchesInfoData } = useQuery(
+    summonerMatchesInfoQuery({ summonerTagName: `${mainAccount?.name}-${mainAccount?.tagLine}` }),
+  );
+  const mainAccountProfile = mainAccountMatchesInfoData?.data.summoner;
+  const mainAccountMatchSummary = mainAccountMatchesInfoData?.data.matchSummary;
   const [otherSummonerName, setOtherSummonerName] = useState('');
-  const { data } = useQuery(summonerInfoQuery({ summonerTagName: otherSummonerName }));
+  const { data } = useQuery(summonerMatchesInfoQuery({ summonerTagName: otherSummonerName }));
   const otherProfile = data?.data.summoner;
+  const otherProfileMatchSummary = data?.data.matchSummary;
 
-  const selectOtherSummoner = (summonerName: string) => setOtherSummonerName(summonerName);
+  const resetOtherSummoner = () => {
+    setOtherSummonerName('');
+    onSummonerChange('');
+  };
+
+  const selectOtherSummoner = (summonerName: string) => {
+    setOtherSummonerName(summonerName);
+    onSummonerChange(summonerName);
+  };
 
   return (
-    <HStack w="full" h="320px" gap="24px">
-      <SummonerCard summonerType="me" myProfile={myProfile} />
+    <HStack w="full" h="260px" gap="24px">
+      <SummonerCard summonerType="me" profile={mainAccountProfile} matchSummary={mainAccountMatchSummary} />
       {otherProfile ? (
-        <SummonerCard summonerType="other" otherProfile={otherProfile} />
+        <SummonerCard
+          summonerType="other"
+          profile={otherProfile}
+          matchSummary={otherProfileMatchSummary}
+          resetOtherSummoner={resetOtherSummoner}
+        />
       ) : (
-        <SearchBox selectOtherSummoner={selectOtherSummoner} />
+        <Box w="528px" h="full" bg="white" borderRadius="4px" p="20px">
+          <SearchBox selectOtherSummoner={selectOtherSummoner} />
+        </Box>
       )}
     </HStack>
   );
@@ -42,21 +65,26 @@ export default function RecommendedPickSelectSummoner(props: RecommendedPickSele
 
 interface SummonerCardProps {
   summonerType: 'me' | 'other';
-  myProfile?: ProfileEntry;
-  otherProfile?: SummonerDto;
+  profile?: SummonerDto;
+  matchSummary?: MatchSummaryDto;
+  resetOtherSummoner?: () => void;
 }
 
-function SummonerCard({ summonerType, myProfile, otherProfile }: SummonerCardProps) {
-  const summoner = summonerType === 'me' ? myProfile : otherProfile;
+function SummonerCard({ summonerType, profile, matchSummary, resetOtherSummoner }: SummonerCardProps) {
   return (
     <VStack w="528px" h="full" bg="white" borderRadius="4px" p="20px" gap="20px">
       <HStack w="full" h="78px" gap="12px">
-        <Box w="78px" h="78px" position="relative">
-          <IconImage width={78} height={78} radius={39} src={profileIconUrl(1)} alt="소환사 아이콘" />
+        <VStack w="78px" h="78px" position="relative" justify="center">
+          <IconImage
+            width={78}
+            height={78}
+            radius={999}
+            src={profileIconUrl(profile?.profileIconId ?? 1)}
+            alt="소환사 아이콘"
+          />
           <Box
             position="absolute"
             bottom="0"
-            left="0"
             minW="38px"
             p="1px 8px"
             borderRadius="20px"
@@ -64,71 +92,90 @@ function SummonerCard({ summonerType, myProfile, otherProfile }: SummonerCardPro
             color="white"
             textStyle="body"
           >
-            000
+            {profile?.summonerLevel}
           </Box>
-        </Box>
+        </VStack>
+
         <VStack w="full" h="full" gap="12px">
           <HStack w="full" gap="12px">
             <Text textStyle="h2" color="gray800" fontWeight="700">
-              T1 Gumayusi
+              {profile?.summonerName}
             </Text>
             <Text textStyle="h3" color="gray600" fontWeight="400">
-              #KR1
+              #{profile?.tagLine}
             </Text>
           </HStack>
           <HStack w="full" gap="8px">
-            <TierImage tier="unknown" width={28} height={28} />
+            <TierImage tier={profile?.soloTierInfo?.tier ?? 'unknown'} width={28} height={28} />
             <Text textStyle="h3" color="gray800" fontWeight="700">
-              {shortTierName('grandmaster')}
+              {shortTierName(profile?.soloTierInfo?.tier ?? 'unknown', profile?.soloTierInfo?.division)}
             </Text>
             <Text textStyle="h3" color="gray500" fontWeight="400">
-              0,000LP
+              {profile?.soloTierInfo?.lp}
             </Text>
-          </HStack>
-        </VStack>
-        <VStack w="full" h="full" borderRadius="8px" p="16px 20px" gap="12px" align="flex-start">
-          <HStack gap="20px">
-            <Text textStyle="t1" color="gray700" fontWeight="700">
-              20전 14승 6패
-            </Text>
-            <Text textStyle="t1" color={championScoreColor(3.3)} fontWeight="700">
-              3.3평점
-            </Text>
-          </HStack>
-          <HStack w="full" justify="space-between" bgColor="gray100">
-            <HStack gap="12px">
-              {Array(3).map((_, index) => (
-                <Fragment key={index}>
-                  <ChampionIcon championEnName="Xerath" width={48} height={48} radius={24} />
-                  <VStack align="flex-start" gap="4px">
-                    <Text textStyle="t1" color="gray800" fontWeight="700">
-                      100%
-                    </Text>
-                    <Text textStyle="t2" color={championScoreColor(8.0)} fontWeight="400">
-                      8.00 평점
-                    </Text>
-                  </VStack>
-                </Fragment>
-              ))}
-            </HStack>
           </HStack>
         </VStack>
         {summonerType === 'other' && (
           <Button
-            w="full"
-            h="48px"
+            type="button"
+            alignSelf="flex-start"
             bgColor="gray800"
-            p="14px 12px"
-            borderRadius="4px"
-            textStyle="t2"
             color="white"
-            fontWeight="700"
-            textAlign="center"
+            p="4px 8px"
+            borderRadius="20px"
+            onClick={resetOtherSummoner}
           >
-            다른 소환사로 변경하기
+            다른 소환사로 변경
           </Button>
         )}
       </HStack>
+
+      <VStack w="full" h="full" borderRadius="8px" p="16px 20px" gap="12px" bgColor="gray100" align="flex-start">
+        <HStack gap="20px">
+          <Text textStyle="t1" color="gray700" fontWeight="700">
+            {matchSummary?.plays}전 {matchSummary?.wins}승 {matchSummary?.defeats}패
+          </Text>
+          <Text
+            textStyle="t1"
+            color={matchSummary?.isPerfect ? championScoreColor(10) : championScoreColor(matchSummary?.avgKda ?? 0)}
+            fontWeight="700"
+          >
+            {matchSummary?.plays === 0
+              ? ''
+              : matchSummary?.isPerfect
+                ? 'Perfect'
+                : `${`${matchSummary?.avgKda} 평점` ?? 0}`}
+          </Text>
+        </HStack>
+        <HStack w="full" justify="space-between">
+          <HStack gap="12px">
+            {matchSummary?.championSummary.map((championSummary, index) => (
+              <Fragment key={index}>
+                <ChampionIcon
+                  championEnName={championIdEnNameMap[championSummary.championId]}
+                  width={48}
+                  height={48}
+                  radius={24}
+                />
+                <VStack align="flex-start" gap="4px">
+                  <Text textStyle="t1" color="gray800" fontWeight="700">
+                    {(championSummary.winRate * 100).toFixed(2)}%
+                  </Text>
+                  <Text
+                    textStyle="t2"
+                    color={
+                      championSummary.isPerfect ? championScoreColor(10) : championScoreColor(championSummary.avgKda)
+                    }
+                    fontWeight="400"
+                  >
+                    {championSummary.isPerfect ? 'Perfect' : `${`${championSummary.avgKda.toFixed(2)} 평점` ?? 0}`}
+                  </Text>
+                </VStack>
+              </Fragment>
+            ))}
+          </HStack>
+        </HStack>
+      </VStack>
     </VStack>
   );
 }

--- a/src/components/pages/recommended-pick/RecommendedPickSelectSummoner.tsx
+++ b/src/components/pages/recommended-pick/RecommendedPickSelectSummoner.tsx
@@ -20,8 +20,6 @@ export interface RecommendedPickSelectSummonerProps {
 }
 
 export default function RecommendedPickSelectSummoner(props: RecommendedPickSelectSummonerProps) {
-  // TODO: use onSummonerChange
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { myProfile, onSummonerChange } = props;
   const mainAccount = myProfile.riotDependentInfo.riotAccounts.find((account) => account.isMain);
   const { data: mainAccountMatchesInfoData } = useQuery(
@@ -115,6 +113,7 @@ function SummonerCard({ summonerType, profile, matchSummary, resetOtherSummoner 
             </Text>
           </HStack>
         </VStack>
+        {/* TODO: 임시버튼 */}
         {summonerType === 'other' && (
           <Button
             type="button"
@@ -135,6 +134,7 @@ function SummonerCard({ summonerType, profile, matchSummary, resetOtherSummoner 
           <Text textStyle="t1" color="gray700" fontWeight="700">
             {matchSummary?.plays}전 {matchSummary?.wins}승 {matchSummary?.defeats}패
           </Text>
+          {/* TODO: 매치전적에 챔피언서머리가 없는 경우 존재 */}
           <Text
             textStyle="t1"
             color={matchSummary?.isPerfect ? championScoreColor(10) : championScoreColor(matchSummary?.avgKda ?? 0)}

--- a/src/components/pages/recommended-pick/RecommendedPickSelectSummoner.tsx
+++ b/src/components/pages/recommended-pick/RecommendedPickSelectSummoner.tsx
@@ -1,12 +1,16 @@
 import { Box, HStack, Text, VStack, Button } from '@chakra-ui/react';
-import { Fragment } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Fragment, useState } from 'react';
 
-import type { ProfileEntry } from '@/apis/types';
+import summonerInfoQuery from '@/apis/queries/summonerInfoQuery';
+import type { ProfileEntry, SummonerDto } from '@/apis/types';
 import profileIconUrl from '@/apis/utils/profileIconUrl';
 import shortTierName from '@/apis/utils/shortTierName';
 import ChampionIcon from '@/components/common/ChampionIcon';
 import IconImage from '@/components/common/IconImage';
 import TierImage from '@/components/common/TierImage';
+
+import SearchBox from './SearchBox';
 
 export interface RecommendedPickSelectSummonerProps {
   myProfile: ProfileEntry;
@@ -18,15 +22,32 @@ export default function RecommendedPickSelectSummoner(props: RecommendedPickSele
   // TODO: use onSummonerChange
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { myProfile, onSummonerChange } = props;
+  const [otherSummonerName, setOtherSummonerName] = useState('');
+  const { data } = useQuery(summonerInfoQuery({ summonerTagName: otherSummonerName }));
+  const otherProfile = data?.data.summoner;
 
-  return <HStack w="full" h="320px" gap="24px" />;
+  const selectOtherSummoner = (summonerName: string) => setOtherSummonerName(summonerName);
+
+  return (
+    <HStack w="full" h="320px" gap="24px">
+      <SummonerCard summonerType="me" myProfile={myProfile} />
+      {otherProfile ? (
+        <SummonerCard summonerType="other" otherProfile={otherProfile} />
+      ) : (
+        <SearchBox selectOtherSummoner={selectOtherSummoner} />
+      )}
+    </HStack>
+  );
 }
 
 interface SummonerCardProps {
   summonerType: 'me' | 'other';
+  myProfile?: ProfileEntry;
+  otherProfile?: SummonerDto;
 }
 
-function SummonerCard({ summonerType }: SummonerCardProps) {
+function SummonerCard({ summonerType, myProfile, otherProfile }: SummonerCardProps) {
+  const summoner = summonerType === 'me' ? myProfile : otherProfile;
   return (
     <VStack w="528px" h="full" bg="white" borderRadius="4px" p="20px" gap="20px">
       <HStack w="full" h="78px" gap="12px">

--- a/src/components/pages/recommended-pick/SearchBox.tsx
+++ b/src/components/pages/recommended-pick/SearchBox.tsx
@@ -14,15 +14,15 @@ export default function SearchBox({ selectOtherSummoner }: SearchBoxProps) {
   const [autoComplete, setAutoComplete] = useState(false);
 
   return (
-    <Box pos="relative">
-      <HStack gap="12px" p="12px 24px" w="420px" bg="white" borderRadius="40px" boxShadow="0 0 0 1px" color="gray200">
+    <Box pos="relative" w="full">
+      <HStack w="full" gap="12px" p="12px 24px" bg="white" borderRadius="40px" boxShadow="0 0 0 1px" color="gray200">
         <Box w="38px">
           <Text textStyle="t2" fontWeight="regular" color="gray800">
             KR
           </Text>
         </Box>
         <Box w="1px" h="24px" bg="gray200" />
-        <HStack as="form" alignItems="center" gap="12px" flex="1 0 0">
+        <HStack w="full" as="form" alignItems="center" gap="12px" flex="1 0 0">
           <Input
             type="search"
             value={searchKeyword}
@@ -55,7 +55,7 @@ export default function SearchBox({ selectOtherSummoner }: SearchBoxProps) {
         borderRadius="4px"
         boxShadow="0 4px 8px rgba(0, 0, 0, 0.1)"
       >
-        {autoComplete && <SearchList keyword={searchKeyword} onCustomXButtonClick={selectOtherSummoner} />}
+        {autoComplete && <SearchList keyword={searchKeyword} onSelect={selectOtherSummoner} />}
       </Box>
     </Box>
   );

--- a/src/components/pages/recommended-pick/SearchBox.tsx
+++ b/src/components/pages/recommended-pick/SearchBox.tsx
@@ -1,0 +1,62 @@
+import { Box, HStack, IconButton, Input, Text } from '@chakra-ui/react';
+import { useState } from 'react';
+
+import SearchIcon from '@/assets/icons/system/search.svg';
+
+import SearchList from '../main/search/SearchList';
+
+interface SearchBoxProps {
+  selectOtherSummoner: (summonerName: string) => void;
+}
+
+export default function SearchBox({ selectOtherSummoner }: SearchBoxProps) {
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [autoComplete, setAutoComplete] = useState(false);
+
+  return (
+    <Box pos="relative">
+      <HStack gap="12px" p="12px 24px" w="420px" bg="white" borderRadius="40px" boxShadow="0 0 0 1px" color="gray200">
+        <Box w="38px">
+          <Text textStyle="t2" fontWeight="regular" color="gray800">
+            KR
+          </Text>
+        </Box>
+        <Box w="1px" h="24px" bg="gray200" />
+        <HStack as="form" alignItems="center" gap="12px" flex="1 0 0">
+          <Input
+            type="search"
+            value={searchKeyword}
+            onChange={(event) => {
+              setSearchKeyword(event.target.value);
+              if (event.target.value.length > 0) {
+                setAutoComplete(true);
+              }
+              if (event.target.value.length === 0) {
+                setAutoComplete(false);
+              }
+            }}
+            textStyle="t2"
+            fontWeight="400"
+            p="0"
+            css={{
+              '::-webkit-search-cancel-button': { display: 'none' },
+            }}
+          />
+          <IconButton type="submit" aria-label="검색" display="inline-flex" color="gray800">
+            <SearchIcon width={24} height={24} />
+          </IconButton>
+        </HStack>
+      </HStack>
+      <Box
+        w="420px"
+        pos="absolute"
+        top="calc(100% + 4px)"
+        bg="white"
+        borderRadius="4px"
+        boxShadow="0 4px 8px rgba(0, 0, 0, 0.1)"
+      >
+        {autoComplete && <SearchList keyword={searchKeyword} onCustomXButtonClick={selectOtherSummoner} />}
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

- 추천 Pick! 페이지 상단 부분입니다
- SearchBox 작업을 하다가 기존 컴포넌트 활용을 위해 약간의 수정을 진행했습니다
  - row의 우측 버튼들이 없어야 함
  - Link가 아니어야 함
- '다른 소환사~' 버튼은 삭제 예정이라 높이를 줄였습니다 / 솔민님이 말씀해주신대로 일단 카드 우상단에 작게 배치했습니다
- onSummonerChange는 string => void로 바꾸면 될 것 같습니다
- 전적데이터/랭크데이터는 있지만 matchSummary - championSummary가 비어있는 경우가 있습니다.