### PR TITLE
feat: move to mypage when click to link with riot

### DIFF
--- a/src/components/pages/account/ModalBody/SignupSuccessModalBody.tsx
+++ b/src/components/pages/account/ModalBody/SignupSuccessModalBody.tsx
@@ -1,4 +1,5 @@
 import { ModalBody } from '@chakra-ui/modal';
+import { Link } from '@chakra-ui/next-js';
 import { Box, Button, Text, VStack } from '@chakra-ui/react';
 import Image from 'next/image';
 
@@ -21,7 +22,17 @@ export default function SignupSuccessModalBody() {
         <Text mt="8px" textStyle="t2" fontWeight="400">
           라이엇 계정 연동 시 더 많은 서비스를 이용할 수 있습니다.
         </Text>
-        <Button mt="40px" variant="default" size="lg" w="160px">
+        <Button
+          as={Link}
+          href="/mypage/info"
+          onClick={onClose}
+          mt="40px"
+          variant="default"
+          size="lg"
+          w="160px"
+          display="flex"
+          textDecor="none"
+        >
           계정 연동하기
         </Button>
       </VStack>


### PR DESCRIPTION
## Summary
회원가입 완료하고 뜨는 창에서 계정 연동하기를 눌렀을 때 모달을 닫고 마이페이지로 이동하도록 변경했습니다.
