### PR TITLE
feat: update relate to mypage schedules

### DIFF
--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -194,9 +194,14 @@ export interface RiotDependentInfo {
   riotAccounts: RiotAccountEntry[];
 }
 
+export interface ScheduleEntryTime {
+  startTime: number;
+  endTime: number;
+}
+
 export interface ScheduleEntry {
   dayOfWeek: DayOfWeek;
-  times: { startTime: number; endTime: number }[];
+  times: ScheduleEntryTime[];
 }
 
 export type DayOfWeek = 'SUNDAY' | 'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY';

--- a/src/components/pages/mypage/changeState/ChangeStateTab.tsx
+++ b/src/components/pages/mypage/changeState/ChangeStateTab.tsx
@@ -29,9 +29,10 @@ export interface ChangeStateTabProps {
 }
 
 export default function ChangeStateTab(props: ChangeStateTabProps) {
+  const { initialStatus, initialIntroduction, initialPreferGameModes, initialSchedules } = props;
+
   const router = useRouter();
 
-  const { initialStatus, initialIntroduction, initialPreferGameModes, initialSchedules } = props;
   const { isOpen: isOpenDrawer, onOpen: onOpenDrawer, onClose: onCloseDrawer } = useDisclosure();
 
   const [status, setStatus] = useState(initialStatus);
@@ -154,7 +155,11 @@ export default function ChangeStateTab(props: ChangeStateTabProps) {
           변경사항 저장
         </Button>
       </Flex>
-      <TimeTableDrawer currentTimeData={emptyIsButtonToggledList()} isOpen={isOpenDrawer} onClose={onCloseDrawer} />
+      <TimeTableDrawer
+        initialIsButtonToggledList={emptyIsButtonToggledList()}
+        isOpen={isOpenDrawer}
+        onClose={onCloseDrawer}
+      />
     </>
   );
 }

--- a/src/components/pages/mypage/changeState/ChangeStateTab.tsx
+++ b/src/components/pages/mypage/changeState/ChangeStateTab.tsx
@@ -13,7 +13,7 @@ import IconCheckbox from '@/components/icons/IconCheckbox';
 import ContentsContainer from '@/components/pages/mypage/ContentsContainer';
 
 import StateMessageInput from './StateMessageInput';
-import TimeTableDrawer, { emptyIsButtonToggledList } from './TimeTableDrawer';
+import TimeTableDrawer, { type TimeTableDrawerProps } from './TimeTableDrawer';
 
 import type { CheckboxProps } from '@chakra-ui/react';
 
@@ -38,14 +38,17 @@ export default function ChangeStateTab(props: ChangeStateTabProps) {
   const [status, setStatus] = useState(initialStatus);
   const [introduction, setIntroduction] = useState(initialIntroduction);
   const [preferGameModes, setPreferGameModes] = useState(initialPreferGameModes);
-  // TODO: 백엔드 분들과 얘기 나눠 본 후에 완성
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [schedules, setSchedules] = useState(initialSchedules);
 
   const { changeProfile } = useChangeProfile();
 
   const handlePreferGameModesChange = (modes: GameMode[]) => {
     setPreferGameModes(modes.map((mode) => ({ gameMode: mode })));
+  };
+
+  const handleTimeTableSaveButtonClick: TimeTableDrawerProps['onSaveButtonClick'] = (newSchedules) => {
+    setSchedules(newSchedules);
+    onCloseDrawer();
   };
 
   return (
@@ -156,9 +159,10 @@ export default function ChangeStateTab(props: ChangeStateTabProps) {
         </Button>
       </Flex>
       <TimeTableDrawer
-        initialIsButtonToggledList={emptyIsButtonToggledList()}
+        initialSchedules={schedules}
         isOpen={isOpenDrawer}
         onClose={onCloseDrawer}
+        onSaveButtonClick={handleTimeTableSaveButtonClick}
       />
     </>
   );

--- a/src/components/pages/mypage/changeState/ChangeStateTab.tsx
+++ b/src/components/pages/mypage/changeState/ChangeStateTab.tsx
@@ -10,10 +10,10 @@ import Check from '@/assets/icons/system/check.svg';
 import StatusIndicator from '@/components/common/StatusIndicator';
 import TimeBadge from '@/components/common/TimeBadge';
 import IconCheckbox from '@/components/icons/IconCheckbox';
-import TimeTableDrawer from '@/components/pages/mypage/changeState/TimeTableDrawer';
 import ContentsContainer from '@/components/pages/mypage/ContentsContainer';
 
 import StateMessageInput from './StateMessageInput';
+import TimeTableDrawer, { emptyIsButtonToggledList } from './TimeTableDrawer';
 
 import type { CheckboxProps } from '@chakra-ui/react';
 
@@ -154,7 +154,7 @@ export default function ChangeStateTab(props: ChangeStateTabProps) {
           변경사항 저장
         </Button>
       </Flex>
-      <TimeTableDrawer currentTimeData={[0, 0, 0, 0, 0, 0, 0]} isOpen={isOpenDrawer} onClose={onCloseDrawer} />
+      <TimeTableDrawer currentTimeData={emptyIsButtonToggledList()} isOpen={isOpenDrawer} onClose={onCloseDrawer} />
     </>
   );
 }

--- a/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
+++ b/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
@@ -14,31 +14,50 @@ import {
 } from '@chakra-ui/react';
 import { useEffect, useRef, useState } from 'react';
 
+import type { DayOfWeek, ScheduleEntry } from '@/apis/types';
 import rawToScheduleEntryTimes from '@/utils/scheduleEntry/rawToScheduleEntryTimes';
+import scheduleEntryTimesToRaw from '@/utils/scheduleEntry/scheduleEntryTimesToRaw';
 import useLazyRef from '@/utils/useLazyRef';
 
-const _emptyIsButtonToggledList = Array.from({ length: 7 }).map(() => Array(24).fill(false) as boolean[]);
-export const emptyIsButtonToggledList = () => structuredClone(_emptyIsButtonToggledList);
+const schedulesToIsButtonToggledList = (schedules: ScheduleEntry[]): boolean[][] =>
+  schedules.map((scheduleEntry) => scheduleEntryTimesToRaw(scheduleEntry.times));
 
-interface TimeTableDrawerProps {
-  initialIsButtonToggledList: boolean[][];
+const DAY_OF_WEEKS: DayOfWeek[] = [
+  'MONDAY',
+  'TUESDAY',
+  'WEDNESDAY',
+  'THURSDAY',
+  'FRIDAY',
+  'SATURDAY',
+  'SUNDAY',
+] satisfies DayOfWeek[];
+const isButtonToggledListToSchedules = (isButtonToggledList: boolean[][]) =>
+  DAY_OF_WEEKS.map((dayOfWeek, i) => ({
+    dayOfWeek,
+    times: rawToScheduleEntryTimes(isButtonToggledList[i]),
+  }));
+
+export interface TimeTableDrawerProps {
+  initialSchedules: ScheduleEntry[];
   isOpen: boolean;
   onClose: () => void;
+  onSaveButtonClick: (newSchedules: ScheduleEntry[]) => void;
 }
 
 export default function TimeTableDrawer(props: TimeTableDrawerProps) {
-  const { initialIsButtonToggledList, isOpen, onClose } = props;
+  const { initialSchedules, isOpen, onClose, onSaveButtonClick } = props;
 
   const [isButtonToggledList, setIsButtonToggledList] = useState<boolean[][]>(() =>
-    structuredClone(initialIsButtonToggledList),
+    schedulesToIsButtonToggledList(initialSchedules),
   );
   const prevIsButtonToggledListRef = useLazyRef(() => structuredClone(isButtonToggledList));
 
   const startPosRef = useRef<[number, number]>();
 
   const handleResetButtonClick = () => {
-    setIsButtonToggledList(structuredClone(initialIsButtonToggledList));
-    prevIsButtonToggledListRef.current = structuredClone(initialIsButtonToggledList);
+    const newIsButtonToggledList = schedulesToIsButtonToggledList(initialSchedules);
+    setIsButtonToggledList(structuredClone(newIsButtonToggledList));
+    prevIsButtonToggledListRef.current = structuredClone(newIsButtonToggledList);
   };
 
   const handleMouseDown = (x: number, y: number) => {
@@ -87,6 +106,10 @@ export default function TimeTableDrawer(props: TimeTableDrawerProps) {
       }
     }
     setIsButtonToggledList(newIsButtonToggledList);
+  };
+
+  const handleSaveButtonClick = () => {
+    onSaveButtonClick(isButtonToggledListToSchedules(isButtonToggledList));
   };
 
   return (
@@ -171,7 +194,7 @@ export default function TimeTableDrawer(props: TimeTableDrawerProps) {
           >
             초기화
           </Button>
-          <Button size="lg" variant="default" w="full" onClick={onClose}>
+          <Button size="lg" variant="default" w="full" onClick={handleSaveButtonClick}>
             선택 완료
           </Button>
         </DrawerFooter>

--- a/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
+++ b/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
@@ -41,6 +41,9 @@ export default function TimeTableDrawer(props: TimeTableDrawerProps) {
   };
 
   const handleMouseDown = (x: number, y: number) => {
+    const newIsButtonToggledList = structuredClone(prevIsButtonToggledListRef.current);
+    newIsButtonToggledList[x][y] = !newIsButtonToggledList[x][y];
+    setIsButtonToggledList(newIsButtonToggledList);
     startPosRef.current = [x, y];
   };
 

--- a/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
+++ b/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
@@ -36,8 +36,8 @@ export default function TimeTableDrawer(props: TimeTableDrawerProps) {
   const startPosRef = useRef<[number, number]>();
 
   const handleResetButtonClick = () => {
-    setIsButtonToggledList(emptyIsButtonToggledList());
-    prevIsButtonToggledListRef.current = emptyIsButtonToggledList();
+    setIsButtonToggledList(structuredClone(initialIsButtonToggledList));
+    prevIsButtonToggledListRef.current = structuredClone(initialIsButtonToggledList);
   };
 
   const handleMouseDown = (x: number, y: number) => {

--- a/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
+++ b/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
@@ -20,46 +20,49 @@ const _emptyIsButtonToggledList = Array.from({ length: 7 }).map(() => Array(24).
 export const emptyIsButtonToggledList = () => structuredClone(_emptyIsButtonToggledList);
 
 interface TimeTableDrawerProps {
-  currentTimeData: boolean[][];
+  initialIsButtonToggledList: boolean[][];
   isOpen: boolean;
   onClose: () => void;
 }
 
 export default function TimeTableDrawer(props: TimeTableDrawerProps) {
-  const { currentTimeData, isOpen, onClose } = props;
+  const { initialIsButtonToggledList, isOpen, onClose } = props;
 
-  const [isButtonToggledList, setIsButtonToggledList] = useState<boolean[][]>(() => structuredClone(currentTimeData));
+  const [isButtonToggledList, setIsButtonToggledList] = useState<boolean[][]>(() =>
+    structuredClone(initialIsButtonToggledList),
+  );
   const prevIsButtonToggledListRef = useLazyRef(() => structuredClone(isButtonToggledList));
 
   const startPosRef = useRef<[number, number]>();
 
-  const resetTimeState = () => {
+  const handleResetButtonClick = () => {
     setIsButtonToggledList(emptyIsButtonToggledList());
     prevIsButtonToggledListRef.current = emptyIsButtonToggledList();
   };
 
-  const onMouseDown = (weekIndex: number, timeIndex: number) => {
-    startPosRef.current = [weekIndex, timeIndex];
+  const handleMouseDown = (x: number, y: number) => {
+    startPosRef.current = [x, y];
   };
 
-  const onMouseUp = () => {
+  const handleMouseUp = () => {
     startPosRef.current = undefined;
     prevIsButtonToggledListRef.current = structuredClone(isButtonToggledList);
   };
 
-  const onMouseOver = (weekIndex: number, timeIndex: number) => {
-    if (startPosRef.current !== undefined) {
-      const [startX, startY] = startPosRef.current;
-      const [smallX, largeX] = [startX, weekIndex].sort((a, b) => a - b);
-      const [smallY, largeY] = [startY, timeIndex].sort((a, b) => a - b);
-      const newIsButtonToggledList = structuredClone(prevIsButtonToggledListRef.current);
-      for (let x = smallX; x <= largeX; x += 1) {
-        for (let y = smallY; y <= largeY; y += 1) {
-          newIsButtonToggledList[x][y] = !prevIsButtonToggledListRef.current[startX][startY];
-        }
-      }
-      setIsButtonToggledList(newIsButtonToggledList);
+  const handleMouseOver = (currentX: number, currentY: number) => {
+    if (startPosRef.current === undefined) {
+      return;
     }
+    const [startX, startY] = startPosRef.current;
+    const [smallX, largeX] = [startX, currentX].sort((a, b) => a - b);
+    const [smallY, largeY] = [startY, currentY].sort((a, b) => a - b);
+    const newIsButtonToggledList = structuredClone(prevIsButtonToggledListRef.current);
+    for (let x = smallX; x <= largeX; x += 1) {
+      for (let y = smallY; y <= largeY; y += 1) {
+        newIsButtonToggledList[x][y] = !prevIsButtonToggledListRef.current[startX][startY];
+      }
+    }
+    setIsButtonToggledList(newIsButtonToggledList);
   };
 
   return (
@@ -113,19 +116,19 @@ export default function TimeTableDrawer(props: TimeTableDrawerProps) {
               gridTemplateRows="repeat(24, 20px)"
               gridAutoFlow="column"
               gridGap="4px"
-              onMouseUp={onMouseUp}
+              onMouseUp={handleMouseUp}
             >
               {isButtonToggledList.flatMap((isToggledList, weekIndex) =>
-                isToggledList.map((isToggled, timeIndex) => (
+                isToggledList.map((isToggled, hourIndex) => (
                   <GridItem
                     as={Button}
-                    // "4-4" 등의 낮은 숫자에서 겹치는 걸 막기 위해 `timeIndex`에 100을 곱함.
-                    key={`${weekIndex}-${timeIndex * 100}`}
+                    // "4-4" 등의 낮은 숫자에서 겹치는 걸 막기 위해 `hourIndex`에 100을 곱함.
+                    key={`${weekIndex}-${hourIndex * 100}`}
                     onMouseDown={() => {
-                      onMouseDown(weekIndex, timeIndex);
+                      handleMouseDown(weekIndex, hourIndex);
                     }}
                     onMouseOver={() => {
-                      onMouseOver(weekIndex, timeIndex);
+                      handleMouseOver(weekIndex, hourIndex);
                     }}
                     bg={isToggled ? 'red800' : 'gray200'}
                   />
@@ -135,7 +138,14 @@ export default function TimeTableDrawer(props: TimeTableDrawerProps) {
           </Grid>
         </DrawerBody>
         <DrawerFooter gap="12px">
-          <Button size="lg" variant="line" px="16px" textColor="gray500" fontWeight="400" onClick={resetTimeState}>
+          <Button
+            size="lg"
+            variant="line"
+            px="16px"
+            textColor="gray500"
+            fontWeight="400"
+            onClick={handleResetButtonClick}
+          >
             초기화
           </Button>
           <Button size="lg" variant="default" w="full" onClick={onClose}>

--- a/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
+++ b/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
@@ -12,7 +12,7 @@ import {
   GridItem,
   Text,
 } from '@chakra-ui/react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import useLazyRef from '@/utils/useLazyRef';
 
@@ -47,10 +47,21 @@ export default function TimeTableDrawer(props: TimeTableDrawerProps) {
     startPosRef.current = [x, y];
   };
 
-  const handleMouseUp = () => {
-    startPosRef.current = undefined;
-    prevIsButtonToggledListRef.current = structuredClone(isButtonToggledList);
-  };
+  useEffect(() => {
+    const handleMouseUp = () => {
+      if (startPosRef.current === undefined) {
+        return;
+      }
+
+      startPosRef.current = undefined;
+      prevIsButtonToggledListRef.current = structuredClone(isButtonToggledList);
+    };
+
+    document.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isButtonToggledList, prevIsButtonToggledListRef]);
 
   const handleMouseOver = (currentX: number, currentY: number) => {
     if (startPosRef.current === undefined) {
@@ -119,7 +130,6 @@ export default function TimeTableDrawer(props: TimeTableDrawerProps) {
               gridTemplateRows="repeat(24, 20px)"
               gridAutoFlow="column"
               gridGap="4px"
-              onMouseUp={handleMouseUp}
             >
               {isButtonToggledList.flatMap((isToggledList, weekIndex) =>
                 isToggledList.map((isToggled, hourIndex) => (

--- a/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
+++ b/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
@@ -14,6 +14,7 @@ import {
 } from '@chakra-ui/react';
 import { useEffect, useRef, useState } from 'react';
 
+import rawToScheduleEntryTimes from '@/utils/scheduleEntry/rawToScheduleEntryTimes';
 import useLazyRef from '@/utils/useLazyRef';
 
 const _emptyIsButtonToggledList = Array.from({ length: 7 }).map(() => Array(24).fill(false) as boolean[]);
@@ -54,7 +55,16 @@ export default function TimeTableDrawer(props: TimeTableDrawerProps) {
       }
 
       startPosRef.current = undefined;
-      prevIsButtonToggledListRef.current = structuredClone(isButtonToggledList);
+      const entryTimesCount = isButtonToggledList.reduce(
+        (count, isToggledList) => count + rawToScheduleEntryTimes(isToggledList).length,
+        0,
+      );
+      if (entryTimesCount > 3) {
+        alert('각 요일에 최대 3개의 시간대 설정이 가능합니다.');
+        setIsButtonToggledList(structuredClone(prevIsButtonToggledListRef.current));
+      } else {
+        prevIsButtonToggledListRef.current = structuredClone(isButtonToggledList);
+      }
     };
 
     document.addEventListener('mouseup', handleMouseUp);

--- a/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
+++ b/src/components/pages/mypage/changeState/TimeTableDrawer.tsx
@@ -12,52 +12,53 @@ import {
   GridItem,
   Text,
 } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
+import { useRef, useState } from 'react';
+
+import useLazyRef from '@/utils/useLazyRef';
+
+const _emptyIsButtonToggledList = Array.from({ length: 7 }).map(() => Array(24).fill(false) as boolean[]);
+export const emptyIsButtonToggledList = () => structuredClone(_emptyIsButtonToggledList);
 
 interface TimeTableDrawerProps {
-  currentTimeData: number[];
+  currentTimeData: boolean[][];
   isOpen: boolean;
   onClose: () => void;
 }
-export default function TimeTableDrawer({ currentTimeData, isOpen, onClose }: TimeTableDrawerProps) {
-  const [initialButtonState, setInitialButtonState] = useState<number[]>(currentTimeData);
-  const [buttonState, setButtonState] = useState(initialButtonState);
+
+export default function TimeTableDrawer(props: TimeTableDrawerProps) {
+  const { currentTimeData, isOpen, onClose } = props;
+
+  const [isButtonToggledList, setIsButtonToggledList] = useState<boolean[][]>(() => structuredClone(currentTimeData));
+  const prevIsButtonToggledListRef = useLazyRef(() => structuredClone(isButtonToggledList));
+
+  const startPosRef = useRef<[number, number]>();
 
   const resetTimeState = () => {
-    setInitialButtonState(new Array(7).fill(0));
+    setIsButtonToggledList(emptyIsButtonToggledList());
+    prevIsButtonToggledListRef.current = emptyIsButtonToggledList();
   };
 
-  useEffect(() => {
-    setButtonState(initialButtonState);
-  }, [initialButtonState]);
-
-  const [startAxis, setStartAxis] = useState<[number, number] | undefined>();
-
   const onMouseDown = (weekIndex: number, timeIndex: number) => {
-    setStartAxis([weekIndex, timeIndex]);
+    startPosRef.current = [weekIndex, timeIndex];
   };
 
   const onMouseUp = () => {
-    setStartAxis(undefined);
-    setInitialButtonState(buttonState);
+    startPosRef.current = undefined;
+    prevIsButtonToggledListRef.current = structuredClone(isButtonToggledList);
   };
 
   const onMouseOver = (weekIndex: number, timeIndex: number) => {
-    if (startAxis) {
-      const startState = initialButtonState[startAxis[0]] & (1 << startAxis[1]);
-      const length = Math.abs(timeIndex - startAxis[1]) + 1;
-      const mask = ((1 << length) - 1) << Math.min(timeIndex, startAxis[1]);
-
-      const copyState = [...initialButtonState];
-
-      const start = weekIndex < startAxis[0] ? weekIndex : startAxis[0];
-      const end = weekIndex + startAxis[0] - start;
-
-      for (let i = start; i <= end; i++) {
-        copyState[i] = !startState ? copyState[i] | mask : copyState[i] & ~mask;
+    if (startPosRef.current !== undefined) {
+      const [startX, startY] = startPosRef.current;
+      const [smallX, largeX] = [startX, weekIndex].sort((a, b) => a - b);
+      const [smallY, largeY] = [startY, timeIndex].sort((a, b) => a - b);
+      const newIsButtonToggledList = structuredClone(prevIsButtonToggledListRef.current);
+      for (let x = smallX; x <= largeX; x += 1) {
+        for (let y = smallY; y <= largeY; y += 1) {
+          newIsButtonToggledList[x][y] = !prevIsButtonToggledListRef.current[startX][startY];
+        }
       }
-
-      setButtonState(copyState);
+      setIsButtonToggledList(newIsButtonToggledList);
     }
   };
 
@@ -110,22 +111,26 @@ export default function TimeTableDrawer({ currentTimeData, isOpen, onClose }: Ti
               area="table"
               gridTemplateColumns="repeat(7, minmax(44px, auto))"
               gridTemplateRows="repeat(24, 20px)"
+              gridAutoFlow="column"
               gridGap="4px"
               onMouseUp={onMouseUp}
             >
-              {[...Array(24).keys()].map((timeIndex) => {
-                return [...Array(7).keys()].map((weekIndex) => {
-                  return (
-                    <GridItem
-                      as={Button}
-                      key={timeIndex * 24 + weekIndex}
-                      onMouseDown={() => onMouseDown(weekIndex, timeIndex)}
-                      onMouseOver={() => onMouseOver(weekIndex, timeIndex)}
-                      bg={buttonState[weekIndex] & (1 << timeIndex) ? 'red800' : 'gray200'}
-                    />
-                  );
-                });
-              })}
+              {isButtonToggledList.flatMap((isToggledList, weekIndex) =>
+                isToggledList.map((isToggled, timeIndex) => (
+                  <GridItem
+                    as={Button}
+                    // "4-4" 등의 낮은 숫자에서 겹치는 걸 막기 위해 `timeIndex`에 100을 곱함.
+                    key={`${weekIndex}-${timeIndex * 100}`}
+                    onMouseDown={() => {
+                      onMouseDown(weekIndex, timeIndex);
+                    }}
+                    onMouseOver={() => {
+                      onMouseOver(weekIndex, timeIndex);
+                    }}
+                    bg={isToggled ? 'red800' : 'gray200'}
+                  />
+                )),
+              )}
             </GridItem>
           </Grid>
         </DrawerBody>

--- a/src/utils/scheduleEntry/rawToScheduleEntryTimes.spec.ts
+++ b/src/utils/scheduleEntry/rawToScheduleEntryTimes.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest';
+
+import rawToScheduleEntryTimes from './rawToScheduleEntryTimes';
+
+test('rawToScheduleEntryTimes()', () => {
+  expect(
+    rawToScheduleEntryTimes([
+      ...Array.from({ length: 5 }).map(() => false),
+      true,
+      true,
+      ...Array.from({ length: 17 }).map(() => false),
+    ]),
+  ).toStrictEqual([{ startTime: 5, endTime: 7 }]);
+
+  expect(rawToScheduleEntryTimes([false, true, ...Array.from({ length: 22 }).map(() => false)])).toStrictEqual([
+    { startTime: 1, endTime: 2 },
+  ]);
+
+  expect(
+    rawToScheduleEntryTimes([
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      ...Array.from({ length: 14 }).map(() => false),
+    ]),
+  ).toStrictEqual([
+    { startTime: 1, endTime: 2 },
+    { startTime: 6, endTime: 10 },
+  ]);
+
+  expect(rawToScheduleEntryTimes([...Array.from({ length: 23 }).map(() => false), true])).toStrictEqual([
+    { startTime: 23, endTime: 24 },
+  ]);
+
+  expect(rawToScheduleEntryTimes([...Array.from({ length: 22 }).map(() => false), true, false])).toStrictEqual([
+    { startTime: 22, endTime: 23 },
+  ]);
+});

--- a/src/utils/scheduleEntry/rawToScheduleEntryTimes.spec.ts
+++ b/src/utils/scheduleEntry/rawToScheduleEntryTimes.spec.ts
@@ -5,14 +5,14 @@ import rawToScheduleEntryTimes from './rawToScheduleEntryTimes';
 test('rawToScheduleEntryTimes()', () => {
   expect(
     rawToScheduleEntryTimes([
-      ...Array.from({ length: 5 }).map(() => false),
+      ...Array.from({ length: 5 }, () => false),
       true,
       true,
-      ...Array.from({ length: 17 }).map(() => false),
+      ...Array.from({ length: 17 }, () => false),
     ]),
   ).toStrictEqual([{ startTime: 5, endTime: 7 }]);
 
-  expect(rawToScheduleEntryTimes([false, true, ...Array.from({ length: 22 }).map(() => false)])).toStrictEqual([
+  expect(rawToScheduleEntryTimes([false, true, ...Array.from({ length: 22 }, () => false)])).toStrictEqual([
     { startTime: 1, endTime: 2 },
   ]);
 
@@ -28,18 +28,18 @@ test('rawToScheduleEntryTimes()', () => {
       true,
       true,
       true,
-      ...Array.from({ length: 14 }).map(() => false),
+      ...Array.from({ length: 14 }, () => false),
     ]),
   ).toStrictEqual([
     { startTime: 1, endTime: 2 },
     { startTime: 6, endTime: 10 },
   ]);
 
-  expect(rawToScheduleEntryTimes([...Array.from({ length: 23 }).map(() => false), true])).toStrictEqual([
+  expect(rawToScheduleEntryTimes([...Array.from({ length: 23 }, () => false), true])).toStrictEqual([
     { startTime: 23, endTime: 24 },
   ]);
 
-  expect(rawToScheduleEntryTimes([...Array.from({ length: 22 }).map(() => false), true, false])).toStrictEqual([
+  expect(rawToScheduleEntryTimes([...Array.from({ length: 22 }, () => false), true, false])).toStrictEqual([
     { startTime: 22, endTime: 23 },
   ]);
 });

--- a/src/utils/scheduleEntry/rawToScheduleEntryTimes.ts
+++ b/src/utils/scheduleEntry/rawToScheduleEntryTimes.ts
@@ -1,0 +1,35 @@
+import type { ScheduleEntryTime } from '@/apis/types';
+
+const MAX_START_TIME = 23;
+
+export default function rawToScheduleEntryTimes(raw: boolean[]): ScheduleEntryTime[] {
+  const scheduleEntryTimes: ScheduleEntryTime[] = [];
+
+  // checked가 스트릭 내에서 처음 true일 때 현재 시간을 저장할 변수
+  let startTime: number | undefined = undefined;
+  raw.forEach((checked, currentTime) => {
+    if (checked) {
+      if (currentTime === MAX_START_TIME) {
+        // 현재 시간이 마지막이기 때문에 다음 루프는 없으므로
+        // 현재 시간을 endTime으로 삼아 push
+        scheduleEntryTimes.push({
+          // 만약 startTime이 undefined면 currentTime이 startTime임
+          startTime: startTime ?? MAX_START_TIME,
+          endTime: MAX_START_TIME + 1,
+        });
+        return;
+      }
+
+      if (startTime === undefined) {
+        startTime = currentTime;
+      }
+    } else {
+      if (startTime !== undefined) {
+        scheduleEntryTimes.push({ startTime, endTime: currentTime });
+        startTime = undefined;
+      }
+    }
+  });
+
+  return scheduleEntryTimes;
+}

--- a/src/utils/scheduleEntry/scheduleEntryTimesToRaw.spec.ts
+++ b/src/utils/scheduleEntry/scheduleEntryTimesToRaw.spec.ts
@@ -4,16 +4,16 @@ import scheduleEntryTimesToRaw from './scheduleEntryTimesToRaw';
 
 test('scheduleEntryTimesToRaw()', () => {
   expect(scheduleEntryTimesToRaw([{ startTime: 5, endTime: 7 }])).toStrictEqual([
-    ...Array.from({ length: 5 }).map(() => false),
+    ...Array.from({ length: 5 }, () => false),
     true,
     true,
-    ...Array.from({ length: 17 }).map(() => false),
+    ...Array.from({ length: 17 }, () => false),
   ]);
 
   expect(scheduleEntryTimesToRaw([{ startTime: 1, endTime: 2 }])).toStrictEqual([
     false,
     true,
-    ...Array.from({ length: 22 }).map(() => false),
+    ...Array.from({ length: 22 }, () => false),
   ]);
 
   expect(
@@ -32,16 +32,16 @@ test('scheduleEntryTimesToRaw()', () => {
     true,
     true,
     true,
-    ...Array.from({ length: 14 }).map(() => false),
+    ...Array.from({ length: 14 }, () => false),
   ]);
 
   expect(scheduleEntryTimesToRaw([{ startTime: 23, endTime: 24 }])).toStrictEqual([
-    ...Array.from({ length: 23 }).map(() => false),
+    ...Array.from({ length: 23 }, () => false),
     true,
   ]);
 
   expect(scheduleEntryTimesToRaw([{ startTime: 22, endTime: 23 }])).toStrictEqual([
-    ...Array.from({ length: 22 }).map(() => false),
+    ...Array.from({ length: 22 }, () => false),
     true,
     false,
   ]);

--- a/src/utils/scheduleEntry/scheduleEntryTimesToRaw.spec.ts
+++ b/src/utils/scheduleEntry/scheduleEntryTimesToRaw.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest';
+
+import scheduleEntryTimesToRaw from './scheduleEntryTimesToRaw';
+
+test('scheduleEntryTimesToRaw()', () => {
+  expect(scheduleEntryTimesToRaw([{ startTime: 5, endTime: 7 }])).toStrictEqual([
+    ...Array.from({ length: 5 }).map(() => false),
+    true,
+    true,
+    ...Array.from({ length: 17 }).map(() => false),
+  ]);
+
+  expect(scheduleEntryTimesToRaw([{ startTime: 1, endTime: 2 }])).toStrictEqual([
+    false,
+    true,
+    ...Array.from({ length: 22 }).map(() => false),
+  ]);
+
+  expect(
+    scheduleEntryTimesToRaw([
+      { startTime: 1, endTime: 2 },
+      { startTime: 6, endTime: 10 },
+    ]),
+  ).toStrictEqual([
+    false,
+    true,
+    false,
+    false,
+    false,
+    false,
+    true,
+    true,
+    true,
+    true,
+    ...Array.from({ length: 14 }).map(() => false),
+  ]);
+
+  expect(scheduleEntryTimesToRaw([{ startTime: 23, endTime: 24 }])).toStrictEqual([
+    ...Array.from({ length: 23 }).map(() => false),
+    true,
+  ]);
+
+  expect(scheduleEntryTimesToRaw([{ startTime: 22, endTime: 23 }])).toStrictEqual([
+    ...Array.from({ length: 22 }).map(() => false),
+    true,
+    false,
+  ]);
+});

--- a/src/utils/scheduleEntry/scheduleEntryTimesToRaw.ts
+++ b/src/utils/scheduleEntry/scheduleEntryTimesToRaw.ts
@@ -1,0 +1,11 @@
+import type { ScheduleEntryTime } from '@/apis/types';
+
+export default function scheduleEntryTimesToRaw(times: ScheduleEntryTime[]): boolean[] {
+  const raw = Array.from({ length: 24 }).map(() => false);
+  for (const time of times) {
+    for (let i = time.startTime; i < time.endTime; i += 1) {
+      raw[i] = true;
+    }
+  }
+  return raw;
+}

--- a/src/utils/scheduleEntry/scheduleEntryTimesToRaw.ts
+++ b/src/utils/scheduleEntry/scheduleEntryTimesToRaw.ts
@@ -1,7 +1,7 @@
 import type { ScheduleEntryTime } from '@/apis/types';
 
 export default function scheduleEntryTimesToRaw(times: ScheduleEntryTime[]): boolean[] {
-  const raw = Array.from({ length: 24 }).map(() => false);
+  const raw = Array.from({ length: 24 }, () => false);
   for (const time of times) {
     for (let i = time.startTime; i < time.endTime; i += 1) {
       raw[i] = true;

--- a/src/utils/useLazyRef.ts
+++ b/src/utils/useLazyRef.ts
@@ -1,0 +1,9 @@
+import { useRef, type MutableRefObject } from 'react';
+
+export default function useLazyRef<T>(initializer: () => T): MutableRefObject<T> {
+  const ref = useRef<T | null>(null);
+  if (ref.current === null) {
+    ref.current = initializer();
+  }
+  return ref as MutableRefObject<T>;
+}

--- a/tests/__snapshots__/ddragon-perk-information-list-snapshot.test.ts.snap
+++ b/tests/__snapshots__/ddragon-perk-information-list-snapshot.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`Ddragon perkInformationList snapshot testing > perkIdImgLinkMap snapshot 1`] = `
 {
   "8005": "perk-images/Styles/Precision/PressTheAttack/PressTheAttack.png",
-  "8008": "perk-images/Styles/Precision/LethalTempo/LethalTempoTemp.png",
   "8009": "perk-images/Styles/Precision/PresenceOfMind/PresenceOfMind.png",
   "8010": "perk-images/Styles/Precision/Conqueror/Conqueror.png",
   "8014": "perk-images/Styles/Precision/CoupDeGrace/CoupDeGrace.png",
@@ -13,10 +12,8 @@ exports[`Ddragon perkInformationList snapshot testing > perkIdImgLinkMap snapsho
   "8106": "perk-images/Styles/Domination/UltimateHunter/UltimateHunter.png",
   "8112": "perk-images/Styles/Domination/Electrocute/Electrocute.png",
   "8120": "perk-images/Styles/Domination/GhostPoro/GhostPoro.png",
-  "8124": "perk-images/Styles/Domination/Predator/Predator.png",
   "8126": "perk-images/Styles/Domination/CheapShot/CheapShot.png",
   "8128": "perk-images/Styles/Domination/DarkHarvest/DarkHarvest.png",
-  "8134": "perk-images/Styles/Domination/IngeniousHunter/IngeniousHunter.png",
   "8135": "perk-images/Styles/Domination/TreasureHunter/TreasureHunter.png",
   "8136": "perk-images/Styles/Domination/ZombieWard/ZombieWard.png",
   "8138": "perk-images/Styles/Domination/EyeballCollection/EyeballCollection.png",
@@ -39,8 +36,8 @@ exports[`Ddragon perkInformationList snapshot testing > perkIdImgLinkMap snapsho
   "8304": "perk-images/Styles/Inspiration/MagicalFootwear/MagicalFootwear.png",
   "8306": "perk-images/Styles/Inspiration/HextechFlashtraption/HextechFlashtraption.png",
   "8313": "perk-images/Styles/Inspiration/PerfectTiming/AlchemistCabinet.png",
-  "8316": "perk-images/Styles/Inspiration/MinionDematerializer/MinionDematerializer.png",
-  "8321": "perk-images/Styles/Inspiration/FuturesMarket/FuturesMarket.png",
+  "8316": "perk-images/Styles/Inspiration/JackOfAllTrades/JackofAllTrades2.png",
+  "8321": "perk-images/Styles/Inspiration/CashBack/CashBack2.png",
   "8345": "perk-images/Styles/Inspiration/BiscuitDelivery/BiscuitDelivery.png",
   "8347": "perk-images/Styles/Inspiration/CosmicInsight/CosmicInsight.png",
   "8351": "perk-images/Styles/Inspiration/GlacialAugment/GlacialAugment.png",
@@ -59,10 +56,10 @@ exports[`Ddragon perkInformationList snapshot testing > perkIdImgLinkMap snapsho
   "8463": "perk-images/Styles/Resolve/FontOfLife/FontOfLife.png",
   "8465": "perk-images/Styles/Resolve/Guardian/Guardian.png",
   "8473": "perk-images/Styles/Resolve/BonePlating/BonePlating.png",
-  "9101": "perk-images/Styles/Precision/Overheal.png",
+  "9101": "perk-images/Styles/Precision/AbsorbLife/AbsorbLife.png",
   "9103": "perk-images/Styles/Precision/LegendBloodline/LegendBloodline.png",
   "9104": "perk-images/Styles/Precision/LegendAlacrity/LegendAlacrity.png",
-  "9105": "perk-images/Styles/Precision/LegendTenacity/LegendTenacity.png",
+  "9105": "perk-images/Styles/Precision/LegendHaste/LegendHaste.png",
   "9111": "perk-images/Styles/Precision/Triumph.png",
   "9923": "perk-images/Styles/Domination/HailOfBlades/HailOfBlades.png",
 }
@@ -71,7 +68,6 @@ exports[`Ddragon perkInformationList snapshot testing > perkIdImgLinkMap snapsho
 exports[`Ddragon perkInformationList snapshot testing > perkIdKrNameMap snapshot 1`] = `
 {
   "8005": "집중 공격",
-  "8008": "치명적 속도",
   "8009": "침착",
   "8010": "정복자",
   "8014": "최후의 일격",
@@ -81,10 +77,8 @@ exports[`Ddragon perkInformationList snapshot testing > perkIdKrNameMap snapshot
   "8106": "궁극의 사냥꾼",
   "8112": "감전",
   "8120": "유령 포로",
-  "8124": "포식자",
   "8126": "비열한 한 방",
   "8128": "어둠의 수확",
-  "8134": "영리한 사냥꾼",
   "8135": "보물 사냥꾼",
   "8136": "좀비 와드",
   "8138": "사냥의 증표",
@@ -107,8 +101,8 @@ exports[`Ddragon perkInformationList snapshot testing > perkIdKrNameMap snapshot
   "8304": "마법의 신발",
   "8306": "마법공학 점멸기",
   "8313": "삼중 물약",
-  "8316": "미니언 해체분석기",
-  "8321": "외상",
+  "8316": "다재다능",
+  "8321": "환급",
   "8345": "비스킷 배달",
   "8347": "우주적 통찰력",
   "8351": "빙결 강화",
@@ -127,10 +121,10 @@ exports[`Ddragon perkInformationList snapshot testing > perkIdKrNameMap snapshot
   "8463": "생명의 샘",
   "8465": "수호자",
   "8473": "뼈 방패",
-  "9101": "과다치유",
+  "9101": "생명 흡수",
   "9103": "전설: 핏빛 길",
   "9104": "전설: 민첩함",
-  "9105": "전설: 강인함",
+  "9105": "전설: 가속",
   "9111": "승전보",
   "9923": "칼날비",
 }
@@ -141,7 +135,6 @@ exports[`Ddragon perkInformationList snapshot testing > perkMap snapshot 1`] = `
   "8000": [
     [
       8005,
-      8008,
       8021,
       8010,
     ],
@@ -164,7 +157,6 @@ exports[`Ddragon perkInformationList snapshot testing > perkMap snapshot 1`] = `
   "8100": [
     [
       8112,
-      8124,
       8128,
       9923,
     ],
@@ -180,7 +172,6 @@ exports[`Ddragon perkInformationList snapshot testing > perkMap snapshot 1`] = `
     ],
     [
       8135,
-      8134,
       8105,
       8106,
     ],
@@ -216,17 +207,17 @@ exports[`Ddragon perkInformationList snapshot testing > perkMap snapshot 1`] = `
     [
       8306,
       8304,
-      8313,
+      8321,
     ],
     [
-      8321,
-      8316,
+      8313,
+      8352,
       8345,
     ],
     [
       8347,
       8410,
-      8352,
+      8316,
     ],
   ],
   "8400": [


### PR DESCRIPTION
## Summary
마이페이지의 스케줄 관련 코드들을 업데이트했습니다.

## Describe your changes
아래의 작업들을 진행했는데 전부 커밋단위로 나눠놨으니 아마 커밋단위 별로 보시면 작업흐름 보기에 편하실거예요.

- 테스트를 하면서 작업을 진행했는데 기존의 스냅샷 테스트가 실패해서 기존의 테스트 스냅샷을 업데이트했습니다.
- 기존에 버튼을 한번 클릭했을 때는 투글이 안되던 것을 고쳤습니다.
- 타임 테이블에서 드래그 후 테이블 바깥에서 마우스 클릭을 뗐을 때 버그가 발생하는 현상을 고쳤습니다.
- 리셋 버튼이 버튼을 모두 비활성화 시키는 게 아니라 맨 처음의 스케줄 상태로 돌아가도록 변경했습니다.
- 스케줄을 총 3개까지만 설정할 수 있도록 했습니다.
