### PR TITLE
fix: ellipsis summoner name and tag in main page

### DIFF
--- a/src/components/pages/main/RecentMatches.style.tsx
+++ b/src/components/pages/main/RecentMatches.style.tsx
@@ -111,6 +111,10 @@ export const summonerTag = (theme: Theme) =>
     ...theme.fonts.h3,
     fontWeight: 400,
     color: theme.colors.gray600,
+    textOverflow: 'ellipsis',
+    maxWidth: '80px',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
   });
 
 export const summonerName = (theme: Theme) =>
@@ -118,6 +122,10 @@ export const summonerName = (theme: Theme) =>
     ...theme.fonts.h2,
     fontWeight: 700,
     color: theme.colors.gray800,
+    textOverflow: 'ellipsis',
+    maxWidth: '200px',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
   });
 
 export const editIcon = (theme: Theme) =>


### PR DESCRIPTION
## Summary
메인페이지 맨 밑에 소환사 최근 전적 카드에서 소환사 이름과 태그가 길면 말줄임표가 나오도록 변경했습니다.
